### PR TITLE
feat: add Contact section and layout refinements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { LoadingScreen } from "@/components/common/LoadingScreen";
 import { Navbar } from "@/components/common/Navbar";
-import { Hero, Projects, Experience, About } from "@/components/custom/home";
+import { Hero, Projects, Experience, About, Contact } from "@/components/custom/home";
 
 export default function Home() {
   return (
@@ -14,6 +14,7 @@ export default function Home() {
         <Projects />
         <Experience />
         <About />
+        <Contact />
       </main>
     </>
   );

--- a/components/common/Navbar/navbar.tsx
+++ b/components/common/Navbar/navbar.tsx
@@ -530,7 +530,7 @@ function Navbar({ className }: NavbarProps) {
   return (
     <>
       <header
-        className={`fixed top-0 right-0 left-0 z-50 flex h-20 items-center px-6 transition-all duration-500 ${
+        className={`fixed top-0 right-0 left-0 z-50 flex h-20 items-center transition-all duration-500 ${
           scrolled && !isOpen ? "bg-surface" : "bg-transparent"
         } ${className}`}
         role="banner"
@@ -543,7 +543,7 @@ function Navbar({ className }: NavbarProps) {
           aria-hidden="true"
         />
 
-        <div className="mx-auto flex w-full max-w-7xl items-center justify-between">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 sm:px-6">
           <Link
             href="/"
             className="focus-visible:ring-accent focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"

--- a/components/custom/home/About/about.tsx
+++ b/components/custom/home/About/about.tsx
@@ -29,57 +29,59 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
   const titleWords = ["The Person", "Behind The Pixels"];
 
   return (
-    <header className="border-foreground/[0.08] mb-8 border-y py-8 sm:mb-10 sm:py-12 md:mb-12 md:py-16 lg:mb-16 lg:py-20">
-      {/* Section tag — matches Projects pattern */}
-      <motion.div
-        className="mb-4 overflow-clip"
-        initial={{ width: shouldReduceMotion ? "auto" : 0 }}
-        animate={isInView ? { width: "auto" } : {}}
-        transition={{ duration: 0.8, ease }}
-      >
-        <motion.span
-          className="text-foreground inline-block px-3 py-1.5 text-xs font-bold tracking-[0.2em] sm:px-4 sm:py-2"
-          style={{ backgroundColor: ACCENT, fontFamily: "var(--font-display)" }}
-          initial={{ x: shouldReduceMotion ? 0 : -100 }}
-          animate={isInView ? { x: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.3, ease }}
+    <header className="border-foreground/[0.08] border-y py-8 sm:py-12 md:py-16 lg:py-20">
+      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6">
+        {/* Section tag — matches Projects pattern */}
+        <motion.div
+          className="mb-4 overflow-clip"
+          initial={{ width: shouldReduceMotion ? "auto" : 0 }}
+          animate={isInView ? { width: "auto" } : {}}
+          transition={{ duration: 0.8, ease }}
         >
-          ABOUT
-        </motion.span>
-      </motion.div>
-
-      <h2
-        id="about-heading"
-        className="text-foreground mb-3 text-2xl font-black sm:mb-4 sm:text-3xl md:mb-6 md:text-4xl lg:text-5xl xl:text-6xl"
-        style={{ fontFamily: "var(--font-display)" }}
-      >
-        {titleWords.map((word, i) => (
-          <span
-            key={i}
-            className={`inline-block overflow-clip${i === 0 ? "mr-2 sm:mr-3 md:mr-4" : ""}`}
+          <motion.span
+            className="text-foreground inline-block px-3 py-1.5 text-xs font-bold tracking-[0.2em] sm:px-4 sm:py-2"
+            style={{ backgroundColor: ACCENT, fontFamily: "var(--font-display)" }}
+            initial={{ x: shouldReduceMotion ? 0 : -100 }}
+            animate={isInView ? { x: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.3, ease }}
           >
-            <motion.span
-              className="inline-block"
-              style={{ color: i === 1 ? ACCENT : "inherit" }}
-              initial={{ y: shouldReduceMotion ? 0 : "100%" }}
-              animate={isInView ? { y: 0 } : {}}
-              transition={{ duration: 0.6, delay: 0.3 + i * 0.15, ease }}
-            >
-              {word}
-            </motion.span>
-          </span>
-        ))}
-      </h2>
+            ABOUT
+          </motion.span>
+        </motion.div>
 
-      <motion.p
-        className="text-foreground/80 max-w-xl text-sm sm:text-base lg:text-lg"
-        initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
-        animate={isInView ? { opacity: 1, y: 0 } : {}}
-        transition={{ duration: 0.8, delay: 0.6, ease }}
-      >
-        The story behind the code — who I am, how I think, and what drives me to build interfaces
-        that feel alive.
-      </motion.p>
+        <h2
+          id="about-heading"
+          className="text-foreground mb-3 text-2xl font-black sm:mb-4 sm:text-3xl md:mb-6 md:text-4xl lg:text-5xl xl:text-6xl"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          {titleWords.map((word, i) => (
+            <span
+              key={i}
+              className={`inline-block overflow-clip${i === 0 ? "mr-2 sm:mr-3 md:mr-4" : ""}`}
+            >
+              <motion.span
+                className="inline-block"
+                style={{ color: i === 1 ? ACCENT : "inherit" }}
+                initial={{ y: shouldReduceMotion ? 0 : "100%" }}
+                animate={isInView ? { y: 0 } : {}}
+                transition={{ duration: 0.6, delay: 0.3 + i * 0.15, ease }}
+              >
+                {word}
+              </motion.span>
+            </span>
+          ))}
+        </h2>
+
+        <motion.p
+          className="text-foreground/80 max-w-xl text-sm sm:text-base lg:text-lg"
+          initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.8, delay: 0.6, ease }}
+        >
+          The story behind the code — who I am, how I think, and what drives me to build interfaces
+          that feel alive.
+        </motion.p>
+      </div>
     </header>
   );
 }
@@ -330,7 +332,7 @@ export default function About() {
 
   const { scrollYProgress } = useScroll({
     target: sectionRef,
-    offset: ["start 0.7", "end 0.1"],
+    offset: ["start 0.15", "end 0.6"],
   });
 
   const photoY = useTransform(scrollYProgress, [0, 1], shouldReduceMotion ? [0, 0] : [-30, 30]);
@@ -351,9 +353,9 @@ export default function About() {
       style={{ backgroundColor: "var(--color-background)" }}
       aria-labelledby="about-heading"
     >
-      <div className="mx-auto w-full max-w-7xl px-4 sm:px-6">
-        <SectionHeader isInView={isInView} />
+      <SectionHeader isInView={isInView} />
 
+      <div className="mx-auto w-full max-w-7xl px-4 pt-8 sm:px-6 sm:pt-10 md:pt-12 lg:pt-16">
         <div className="relative flex flex-col-reverse gap-8 sm:gap-10 md:gap-12 lg:flex-row lg:gap-20">
           {/* Left: Scroll-driven word reveal */}
           <motion.div
@@ -365,8 +367,8 @@ export default function About() {
               style={{ fontFamily: "var(--font-display)" }}
             >
               {words.map((word, i) => {
-                const start = (i / totalWords) * 0.85;
-                const end = start + 0.85 / totalWords;
+                const start = (i / totalWords) * 0.75;
+                const end = start + 0.75 / totalWords;
                 return (
                   <ScrollWord
                     key={i}

--- a/components/custom/home/Contact/contact.test.tsx
+++ b/components/custom/home/Contact/contact.test.tsx
@@ -1,0 +1,204 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const filterMotionProps = (props: Record<string, unknown>) => {
+  const motionPropKeys = [
+    "initial",
+    "animate",
+    "exit",
+    "transition",
+    "whileHover",
+    "whileTap",
+    "whileInView",
+    "whileFocus",
+    "whileDrag",
+    "viewport",
+    "variants",
+    "layout",
+    "layoutId",
+    "onAnimationStart",
+    "onAnimationComplete",
+  ];
+  const filtered: Record<string, unknown> = {};
+  for (const key in props) {
+    if (!motionPropKeys.includes(key)) {
+      filtered[key] = props[key];
+    }
+  }
+  return filtered;
+};
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...filterMotionProps(props)}>{children}</div>
+    ),
+    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <span {...filterMotionProps(props)}>{children}</span>
+    ),
+    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <p {...filterMotionProps(props)}>{children}</p>
+    ),
+    section: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <section {...filterMotionProps(props)}>{children}</section>
+    ),
+    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <button {...filterMotionProps(props)}>{children}</button>
+    ),
+    a: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <a {...filterMotionProps(props)}>{children}</a>
+    ),
+  },
+  useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+  useTransform: () => ({ get: () => 0 }),
+  useSpring: () => ({ get: () => 0, set: () => {} }),
+  useMotionValue: () => ({ get: () => 0, set: () => {} }),
+  useReducedMotion: () => false,
+  useInView: () => true,
+}));
+
+jest.mock("lucide-react", () => ({
+  Github: ({ className }: any) => <svg data-testid="github-icon" className={className} />,
+  Linkedin: ({ className }: any) => <svg data-testid="linkedin-icon" className={className} />,
+  Mail: ({ className }: any) => <svg data-testid="mail-icon" className={className} />,
+  Copy: ({ className }: any) => <svg data-testid="copy-icon" className={className} />,
+  Check: ({ className }: any) => <svg data-testid="check-icon" className={className} />,
+}));
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  },
+});
+
+import Contact from "./contact";
+
+describe("Contact Section", () => {
+  describe("Rendering", () => {
+    it("renders the section with correct id", () => {
+      render(<Contact />);
+      expect(document.getElementById("contact")).toBeInTheDocument();
+    });
+
+    it("renders all manifesto lines", () => {
+      render(<Contact />);
+      expect(screen.getByText("Make it fast.")).toBeInTheDocument();
+      expect(screen.getByText("Make it beautiful.")).toBeInTheDocument();
+      expect(screen.getByText("Make it accessible.")).toBeInTheDocument();
+      expect(screen.getByText("Make it memorable.")).toBeInTheDocument();
+      expect(screen.getByText("Make it right.")).toBeInTheDocument();
+    });
+
+    it("renders the copy email button with email address", () => {
+      render(<Contact />);
+      expect(screen.getByText("diego@example.com")).toBeInTheDocument();
+    });
+
+    it("renders all social link buttons", () => {
+      render(<Contact />);
+      expect(screen.getByLabelText("LinkedIn")).toBeInTheDocument();
+      expect(screen.getByLabelText("GitHub")).toBeInTheDocument();
+      expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    });
+
+    it("social links have correct href attributes", () => {
+      render(<Contact />);
+      expect(screen.getByLabelText("LinkedIn")).toHaveAttribute(
+        "href",
+        "https://linkedin.com/in/drsm"
+      );
+      expect(screen.getByLabelText("GitHub")).toHaveAttribute(
+        "href",
+        "https://github.com/DiegoRSM03"
+      );
+      expect(screen.getByLabelText("Email")).toHaveAttribute("href", "mailto:diego@example.com");
+    });
+
+    it("social links open in new tab", () => {
+      render(<Contact />);
+      const links = [
+        screen.getByLabelText("LinkedIn"),
+        screen.getByLabelText("GitHub"),
+        screen.getByLabelText("Email"),
+      ];
+      links.forEach((link) => {
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      });
+    });
+  });
+
+  describe("Copy Email Interaction", () => {
+    it("copies email to clipboard on click", () => {
+      render(<Contact />);
+      const button = screen.getByText("diego@example.com").closest("button")!;
+      fireEvent.click(button);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("diego@example.com");
+    });
+
+    it("shows 'Copied!' text after clicking", () => {
+      render(<Contact />);
+      const button = screen.getByText("diego@example.com").closest("button")!;
+      fireEvent.click(button);
+      expect(screen.getByText("Copied!")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has correct aria-labelledby on section", () => {
+      render(<Contact />);
+      const section = document.getElementById("contact");
+      expect(section).toHaveAttribute("aria-labelledby", "contact-heading");
+    });
+
+    it("has a screen-reader heading with correct id", () => {
+      render(<Contact />);
+      const heading = screen.getByRole("heading", { name: "Contact" });
+      expect(heading).toHaveAttribute("id", "contact-heading");
+    });
+
+    it("heading is visually hidden with sr-only", () => {
+      render(<Contact />);
+      const heading = screen.getByRole("heading", { name: "Contact" });
+      expect(heading).toHaveClass("sr-only");
+    });
+
+    it("heading hierarchy is correct (h2 present)", () => {
+      render(<Contact />);
+      const heading = screen.getByRole("heading", { name: "Contact" });
+      expect(heading.tagName).toBe("H2");
+    });
+
+    it("social links nav has aria-label", () => {
+      render(<Contact />);
+      expect(screen.getByRole("navigation", { name: "Social links" })).toBeInTheDocument();
+    });
+
+    it("each social link has descriptive aria-label", () => {
+      render(<Contact />);
+      expect(screen.getByLabelText("LinkedIn")).toBeInTheDocument();
+      expect(screen.getByLabelText("GitHub")).toBeInTheDocument();
+      expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    });
+
+    it("decorative shapes are hidden from screen readers", () => {
+      render(<Contact />);
+      const decorativeElements = document.querySelectorAll('[aria-hidden="true"]');
+      expect(decorativeElements.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("divider is hidden from screen readers", () => {
+      render(<Contact />);
+      const dividers = document.querySelectorAll('[aria-hidden="true"]');
+      const hasDivider = Array.from(dividers).some((el) => el.classList.contains("origin-left"));
+      expect(hasDivider).toBe(true);
+    });
+
+    it("copy email button is keyboard accessible", () => {
+      render(<Contact />);
+      const button = screen.getByText("diego@example.com").closest("button")!;
+      expect(button.tagName).toBe("BUTTON");
+    });
+  });
+});

--- a/components/custom/home/Contact/contact.tsx
+++ b/components/custom/home/Contact/contact.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useSpring,
+  useMotionValue,
+  useReducedMotion,
+  useInView,
+} from "framer-motion";
+import { Github, Linkedin, Mail, Copy, Check } from "lucide-react";
+
+const ACCENT = "#8B5CF6";
+const CYAN = "#06B6D4";
+const PINK = "#EC4899";
+const AMBER = "#F59E0B";
+const GREEN = "#10B981";
+const ease = [0.22, 1, 0.36, 1] as const;
+
+const SOCIAL_LINKS = [
+  { label: "LinkedIn", href: "https://linkedin.com/in/drsm", icon: Linkedin },
+  { label: "GitHub", href: "https://github.com/DiegoRSM03", icon: Github },
+  { label: "Email", href: "mailto:diego@example.com", icon: Mail },
+];
+
+const EMAIL = "diego@example.com";
+
+// ============================================================================
+// MagneticWrapper — reusable magnetic hover effect
+// ============================================================================
+
+function MagneticWrapper({
+  children,
+  className,
+  strength = 0.3,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  strength?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const shouldReduceMotion = useReducedMotion();
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+  const springX = useSpring(x, { stiffness: 150, damping: 15 });
+  const springY = useSpring(y, { stiffness: 150, damping: 15 });
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!ref.current || shouldReduceMotion) return;
+    const rect = ref.current.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    x.set((e.clientX - centerX) * strength);
+    y.set((e.clientY - centerY) * strength);
+  };
+
+  const handleMouseLeave = () => {
+    x.set(0);
+    y.set(0);
+  };
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      style={{ x: springX, y: springY }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+// ============================================================================
+// CopyEmailButton — magnetic + hover/active/focus states + light theme
+// ============================================================================
+
+function CopyEmailButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(EMAIL);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <MagneticWrapper className="inline-block">
+      <motion.button
+        onClick={handleCopy}
+        className="group flex items-center gap-2 border-2 px-3 py-2 text-xs font-semibold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:px-4 sm:py-2.5 sm:text-sm md:px-5 md:py-3 md:text-base"
+        style={{
+          borderColor: copied ? ACCENT : "var(--color-border)",
+          color: copied ? "#fff" : ACCENT,
+          backgroundColor: copied ? ACCENT : "transparent",
+          // @ts-expect-error CSS custom property
+          "--tw-ring-color": ACCENT,
+          "--tw-ring-offset-color": "var(--color-background)",
+        }}
+        whileHover={{
+          borderColor: ACCENT,
+          boxShadow: `0 0 20px ${ACCENT}30`,
+        }}
+        whileTap={{ scale: 0.97 }}
+        transition={{ duration: 0.15 }}
+      >
+        {copied ? (
+          <>
+            <Check className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            Copied!
+          </>
+        ) : (
+          <>
+            <Copy className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            {EMAIL}
+          </>
+        )}
+      </motion.button>
+    </MagneticWrapper>
+  );
+}
+
+// ============================================================================
+// SocialLinkButton — magnetic + hover/active/focus states + light theme
+// ============================================================================
+
+function SocialLinkButton({
+  href,
+  label,
+  icon: Icon,
+}: {
+  href: string;
+  label: string;
+  icon: React.ElementType;
+}) {
+  return (
+    <MagneticWrapper className="inline-block">
+      <motion.a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={label}
+        className="border-border text-muted hover:border-accent hover:text-accent focus-visible:ring-accent active:bg-accent/10 flex h-10 w-10 items-center justify-center border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:h-11 sm:w-11 md:h-12 md:w-12"
+        style={{
+          // @ts-expect-error CSS custom property
+          "--tw-ring-offset-color": "var(--color-background)",
+        }}
+        whileHover={{
+          boxShadow: `0 0 20px ${ACCENT}30`,
+        }}
+        whileTap={{ scale: 0.95 }}
+        transition={{ duration: 0.15 }}
+      >
+        <Icon className="h-4 w-4 sm:h-[18px] sm:w-[18px] md:h-5 md:w-5" />
+      </motion.a>
+    </MagneticWrapper>
+  );
+}
+
+// ============================================================================
+// Contact Section
+// ============================================================================
+
+export default function Contact() {
+  const ref = useRef<HTMLElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const shouldReduceMotion = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+
+  const contentY = useTransform(scrollYProgress, [0, 1], shouldReduceMotion ? [0, 0] : [40, -40]);
+
+  const manifesto = [
+    { text: "Make it fast.", color: CYAN },
+    { text: "Make it beautiful.", color: PINK },
+    { text: "Make it accessible.", color: GREEN },
+    { text: "Make it memorable.", color: AMBER },
+    { text: "Make it right.", color: ACCENT },
+  ];
+
+  return (
+    <section
+      ref={ref}
+      id="contact"
+      className="border-foreground/[0.08] relative flex h-svh w-full items-center overflow-hidden border-t"
+      style={{ backgroundColor: "var(--color-background)" }}
+      aria-labelledby="contact-heading"
+    >
+      {/* Grid background */}
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <svg className="h-full w-full" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <pattern id="contact-grid" width="100" height="100" patternUnits="userSpaceOnUse">
+              <path
+                d="M 100 0 L 0 0 0 100"
+                fill="none"
+                stroke="rgba(255, 255, 255, 0.07)"
+                strokeWidth="1"
+              />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#contact-grid)" />
+        </svg>
+      </div>
+
+      <motion.div
+        className="relative mx-auto w-full max-w-7xl px-4 sm:px-6"
+        style={{ y: contentY }}
+      >
+        <h2 id="contact-heading" className="sr-only">
+          Contact
+        </h2>
+
+        {/* Manifesto */}
+        <div className="mb-8 space-y-0.5 sm:mb-10 sm:space-y-1 md:mb-14 md:space-y-2 lg:mb-16 lg:space-y-3">
+          {manifesto.map((line, i) => (
+            <div key={i} className="overflow-hidden">
+              <motion.p
+                className="text-3xl font-black sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
+                style={{ fontFamily: "var(--font-display)", color: line.color }}
+                initial={{ y: shouldReduceMotion ? 0 : "100%" }}
+                animate={isInView ? { y: 0 } : {}}
+                transition={{ duration: 0.7, delay: 0.6 + i * 0.12, ease }}
+              >
+                {line.text}
+              </motion.p>
+            </div>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <motion.div
+          className="mb-6 h-px origin-left sm:mb-8 md:mb-10"
+          style={{ backgroundColor: `${ACCENT}30` }}
+          initial={{ scaleX: 0 }}
+          animate={isInView ? { scaleX: 1 } : {}}
+          transition={{ duration: 1.2, delay: 1.4, ease }}
+          aria-hidden="true"
+        />
+
+        {/* Actions row */}
+        <motion.div
+          className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 1.8, ease }}
+        >
+          <CopyEmailButton />
+
+          <nav aria-label="Social links" className="flex items-center gap-2 sm:gap-3 md:gap-4">
+            {SOCIAL_LINKS.map((link) => (
+              <SocialLinkButton
+                key={link.label}
+                href={link.href}
+                label={link.label}
+                icon={link.icon}
+              />
+            ))}
+          </nav>
+        </motion.div>
+      </motion.div>
+
+      {/* Floating decorative shapes */}
+      <motion.div
+        className="absolute top-[12%] right-[6%] h-6 w-6 rotate-45 sm:top-[15%] sm:right-[8%] sm:h-8 sm:w-8 md:h-10 md:w-10"
+        style={{ backgroundColor: `${ACCENT}12` }}
+        animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
+        transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }}
+        aria-hidden="true"
+      />
+      <motion.div
+        className="absolute bottom-[15%] left-[4%] h-5 w-5 rounded-full sm:bottom-[20%] sm:left-[6%] sm:h-6 sm:w-6 md:h-8 md:w-8"
+        style={{ backgroundColor: `${PINK}10` }}
+        animate={shouldReduceMotion ? {} : { y: [0, 10, 0] }}
+        transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
+        aria-hidden="true"
+      />
+      <motion.div
+        className="absolute top-[40%] left-[3%] hidden h-5 w-5 sm:block md:h-6 md:w-6"
+        style={{ backgroundColor: `${CYAN}08` }}
+        animate={shouldReduceMotion ? {} : { rotate: [0, 90, 0] }}
+        transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+        aria-hidden="true"
+      />
+    </section>
+  );
+}

--- a/components/custom/home/Contact/index.ts
+++ b/components/custom/home/Contact/index.ts
@@ -1,0 +1,1 @@
+export { default as Contact } from "./contact";

--- a/components/custom/home/Experience/experience.tsx
+++ b/components/custom/home/Experience/experience.tsx
@@ -271,19 +271,12 @@ function ExperienceCard({
         </motion.div>
 
         <motion.div
-          className="border-border bg-background/95 relative -mt-12 border p-4 backdrop-blur-sm sm:-mt-14 sm:p-6 md:-mt-16 md:p-8 lg:-mt-20 lg:ml-4 xl:ml-8"
+          className="border-border relative -mt-12 border p-4 sm:-mt-14 sm:p-6 md:-mt-16 md:p-8 lg:-mt-20 lg:ml-4 xl:ml-8"
           style={{
-            borderColor: isActive
-              ? isDark
-                ? "rgba(255, 255, 255, 0.7)"
-                : "rgba(0, 0, 0, 0.7)"
-              : isDark
-                ? "rgba(255, 255, 255, 0.08)"
-                : "rgba(0, 0, 0, 0.08)",
+            borderColor: isDark ? "#1f1f1f" : "#e5e5e5",
+            backgroundColor: isDark ? "#0a0a0a" : "#fafafa",
             y: useParallax ? springCardY : 0,
           }}
-          animate={{ x: shouldReduceMotion ? 0 : isActive ? 10 : 0 }}
-          transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
         >
           <div
             className="absolute top-4 right-4 hidden items-center gap-2 sm:top-6 sm:right-6 sm:flex"
@@ -390,8 +383,8 @@ function ExperienceCard({
                 key={skill}
                 className="text-foreground border px-2 py-1 text-[10px] font-medium sm:px-3 sm:text-xs"
                 style={{
-                  borderColor: isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)",
-                  backgroundColor: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.03)",
+                  borderColor: isDark ? "#2a2a2a" : "#d4d4d4",
+                  backgroundColor: isDark ? "#1a1a1a" : "#f0f0f0",
                 }}
                 initial={{ opacity: 0, scale: shouldReduceMotion ? 1 : 0.8 }}
                 whileInView={{ opacity: 1, scale: 1 }}
@@ -489,7 +482,7 @@ export default function Experience() {
       <div className="relative flex flex-col lg:flex-row">
         <aside
           className="sticky top-0 hidden h-screen w-full shrink-0 overflow-hidden lg:block lg:w-2/5"
-          style={{ backgroundColor: "#5B21B6" }}
+          style={{ backgroundColor: "var(--color-accent)" }}
           aria-label="Work history navigation"
         >
           <div className="absolute inset-0" aria-hidden="true">
@@ -521,7 +514,10 @@ export default function Experience() {
             </div>
           )}
 
-          <div className="relative z-10 flex h-full flex-col justify-center p-8 xl:p-12">
+          <div
+            className="relative z-10 flex h-full w-full flex-col justify-center p-6 pr-6 sm:p-8 sm:pr-8 xl:p-12 xl:pr-12"
+            style={{ paddingLeft: "max(1.5rem, calc((100vw - 1280px) / 2 + 1rem))" }}
+          >
             <motion.div
               initial={{ x: shouldReduceMotion ? 0 : -50, opacity: 0 }}
               whileInView={{ x: 0, opacity: 1 }}
@@ -596,7 +592,8 @@ export default function Experience() {
 
           <div
             ref={contentRef}
-            className="relative z-10 space-y-20 px-4 py-16 sm:space-y-24 sm:px-6 sm:py-20 md:space-y-32 md:py-24 lg:space-y-40 lg:px-10 lg:py-32 xl:space-y-48 xl:px-12 xl:py-40"
+            className="relative z-10 w-full space-y-20 px-4 py-16 sm:space-y-24 sm:px-6 sm:py-20 md:space-y-32 md:py-24 lg:space-y-40 lg:py-32 lg:pl-8 xl:space-y-48 xl:py-40 xl:pl-10"
+            style={{ paddingRight: "max(1rem, calc((100vw - 1280px) / 2 + 1.5rem))" }}
           >
             {EXPERIENCES.map((exp, index) => (
               <ExperienceCard

--- a/components/custom/home/Hero/hero.tsx
+++ b/components/custom/home/Hero/hero.tsx
@@ -210,7 +210,7 @@ function Hero() {
       {!isTouch && <CursorShapes enableMotion={enableMotion} />}
 
       <motion.div
-        className="relative z-10 mx-auto flex w-full max-w-7xl flex-col items-center px-6 text-center"
+        className="relative z-10 mx-auto flex w-full max-w-7xl flex-col items-center px-4 text-center sm:px-6"
         style={{ y: y1 }}
       >
         <motion.div

--- a/components/custom/home/index.ts
+++ b/components/custom/home/index.ts
@@ -2,3 +2,4 @@ export { Hero } from "./Hero";
 export { Projects } from "./Projects";
 export { Experience } from "./Experience";
 export { About } from "./About";
+export { Contact } from "./Contact";


### PR DESCRIPTION
## Summary
- Adds Contact section to the homepage: multi-color manifesto ("Make it fast/beautiful/accessible/memorable/right"), copy-to-clipboard email button, magnetic social link buttons
- Fixes 1280px container alignment across Navbar, Hero, Experience, and About sections
- Experience cards: solid hex colors only (no transparency/blur), active state only changes company name highlight
- About section: full-width header borders, tuned scroll-reveal timing
- Contact section: grid background, border-top separator, delayed entrance animations, full viewport height
- 17 unit tests for Contact covering rendering, clipboard, and accessibility

## Test plan
- [x] Verify Contact section renders at bottom of homepage below About
- [x] Click email button — copies to clipboard, shows "Copied!" feedback
- [x] Hover social links — magnetic effect + purple glow
- [x] Tab through buttons — visible focus rings on all interactive elements
- [x] Resize to 1920px+ — verify all section content stays within 1280px boundary
- [x] Experience cards — no blur/transparency, solid dark backgrounds
- [x] Toggle light/dark mode — all sections adapt correctly
- [x] Test on mobile — Contact stacks vertically, manifesto scales down
- [x] Run `pnpm test` — all 101 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)