### PR TITLE
feat: rewrite website copy, real projects, and UX improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Portfolio for a Senior Frontend Engineer. Next.js 16, React 19, TypeScript, Tail
 - LCP < 2.5s, CLS < 0.1 — measure, don't guess
 - Lazy load below-fold content
 - Images via `next/image` only — no external optimization services
-- Animations: transform and opacity only when possible. Always respect `prefers-reduced-motion`.
+- Animations: transform and opacity only when possible
 
 ## Testing
 
@@ -93,8 +93,6 @@ Portfolio for a Senior Frontend Engineer. Next.js 16, React 19, TypeScript, Tail
 
 Before considering any work complete:
 
-1. **Mobile-first** — verify proper mobile, tablet, and desktop breakpoints
-2. **Dark + light mode** — every visual element correct in both themes
-3. **Accessibility** — semantic HTML, WCAG AA contrast, focus states, `aria-*` labels, reduced motion support
-4. **Tests** — unit tests written and passing
-5. **Lint + build** — `pnpm lint` and `pnpm build` pass
+1. **Visual verification** — every UI change must be verified across all 6 combinations: mobile/tablet/desktop × dark/light. Don't assume a fix for one viewport or theme works for the others. Hardcoded colors on themed surfaces break in the opposite mode. Spacing tweaks for mobile can overflow on tablet.
+2. **Tests** — unit tests written and passing
+3. **Lint + build** — `pnpm lint` and `pnpm build` pass

--- a/components/custom/home/About/about.tsx
+++ b/components/custom/home/About/about.tsx
@@ -332,8 +332,8 @@ function RailShapesContainer({ isInView }: { isInView: boolean }) {
 // ============================================================================
 
 const HIGHLIGHTED_WORDS: Record<Locale, string[]> = {
-  en: ["alive.", "natural,", "instant,", "breathe."],
-  es: ["vivas.", "natural,", "instantaneo,", "respirar."],
+  en: ["crafting", "globally.", "alive."],
+  es: ["creando", "global.", "vida."],
 };
 
 export default function About() {

--- a/components/custom/home/Contact/contact.test.tsx
+++ b/components/custom/home/Contact/contact.test.tsx
@@ -91,10 +91,10 @@ describe("Contact Section", () => {
     it("renders all manifesto lines", () => {
       render(<Contact />);
       expect(screen.getByText("Make it fast.")).toBeInTheDocument();
-      expect(screen.getByText("Make it beautiful.")).toBeInTheDocument();
-      expect(screen.getByText("Make it accessible.")).toBeInTheDocument();
-      expect(screen.getByText("Make it memorable.")).toBeInTheDocument();
       expect(screen.getByText("Make it right.")).toBeInTheDocument();
+      expect(screen.getByText("Make it lasting.")).toBeInTheDocument();
+      expect(screen.getByText("Make it memorable.")).toBeInTheDocument();
+      expect(screen.getByText("Make it breathe.")).toBeInTheDocument();
     });
 
     it("renders the copy email button with email address", () => {

--- a/components/custom/home/Contact/contact.tsx
+++ b/components/custom/home/Contact/contact.tsx
@@ -213,10 +213,10 @@ export default function Contact() {
 
   const manifesto = [
     { text: "Make it fast.", color: CYAN_HEX },
-    { text: "Make it beautiful.", color: PINK_HEX },
-    { text: "Make it accessible.", color: GREEN_HEX },
+    { text: "Make it right.", color: PINK_HEX },
+    { text: "Make it lasting.", color: GREEN_HEX },
     { text: "Make it memorable.", color: AMBER_HEX },
-    { text: "Make it right.", color: ACCENT_HEX },
+    { text: "Make it breathe.", color: ACCENT_HEX },
   ];
 
   return (

--- a/components/custom/home/Experience/experience.test.tsx
+++ b/components/custom/home/Experience/experience.test.tsx
@@ -1,4 +1,19 @@
 import { render, screen } from "@testing-library/react";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 import Experience from "./experience";
 
 const filterMotionProps = (props: Record<string, unknown>) => {

--- a/components/custom/home/Experience/experience.tsx
+++ b/components/custom/home/Experience/experience.tsx
@@ -32,8 +32,8 @@ const EXPERIENCES: ExperienceData[] = [
   {
     company: "Inaza",
     i18nKey: "inaza",
-    highlightCount: 3,
-    skills: ["React", "TypeScript", "REST APIs", "CSS"],
+    highlightCount: 4,
+    skills: ["Python", "Vertex AI", "Claude", "Graph API", "Gmail API", "OCR"],
     color: PINK_HEX,
     numberColorDark: "#5C2A45",
     numberColorLight: "#FCE7F3",
@@ -42,7 +42,7 @@ const EXPERIENCES: ExperienceData[] = [
     company: "Litebox",
     i18nKey: "litebox",
     highlightCount: 4,
-    skills: ["Next.js", "AWS", "GSAP", "Framer Motion", "TypeScript", "Strapi"],
+    skills: ["Next.js", "React", "TypeScript", "AWS", "Jest", "GSAP/Framer"],
     color: ACCENT,
     numberColorDark: "#3D2A5C",
     numberColorLight: "#E9E0FF",
@@ -51,7 +51,7 @@ const EXPERIENCES: ExperienceData[] = [
     company: "Axon",
     i18nKey: "axon",
     highlightCount: 4,
-    skills: ["React", "Node.js", "WhatsApp API", "GitHub Actions", "PostgreSQL"],
+    skills: ["Next.js", "React", "TypeScript", "SQL", "SEO"],
     color: CYAN_HEX,
     numberColorDark: "#134E5A",
     numberColorLight: "#CFFAFE",
@@ -335,16 +335,8 @@ function ExperienceCard({
             </ul>
           </motion.div>
 
-          <div className="mb-3 flex items-center gap-2 sm:mb-4 sm:gap-3" aria-hidden="true">
-            <div className="bg-foreground/20 h-px flex-1" />
-            <span className="text-foreground/40 text-[10px] font-medium tracking-wider uppercase sm:text-xs">
-              Stack
-            </span>
-            <div className="bg-foreground/20 h-px flex-1" />
-          </div>
-
           <ul
-            className="flex flex-wrap gap-1.5 sm:gap-2"
+            className="flex flex-wrap gap-1.5 pt-3 sm:gap-2 sm:pt-4"
             role="list"
             aria-label="Technologies used"
           >
@@ -410,11 +402,12 @@ export default function Experience() {
   useEffect(() => {
     const handleScroll = () => {
       if (!contentRef.current) return;
+      const isDesktop = window.matchMedia("(min-width: 1024px)").matches;
+      const triggerPoint = isDesktop ? window.innerHeight / 2 : window.innerHeight * 0.75;
       const cards = contentRef.current.querySelectorAll("[data-experience-card]");
       cards.forEach((card, index) => {
         const rect = card.getBoundingClientRect();
-        const viewportMiddle = window.innerHeight / 2;
-        if (rect.top < viewportMiddle && rect.bottom > viewportMiddle) {
+        if (rect.top < triggerPoint && rect.bottom > triggerPoint) {
           setActiveSection(index);
         }
       });
@@ -435,7 +428,7 @@ export default function Experience() {
 
       <div className="relative flex flex-col lg:flex-row">
         <aside
-          className="sticky top-0 hidden h-screen w-full shrink-0 overflow-hidden lg:block lg:w-2/5"
+          className="sticky top-20 hidden h-[calc(100vh-5rem)] w-full shrink-0 overflow-hidden lg:block lg:w-2/5"
           style={{ backgroundColor: ACCENT }}
           aria-label="Work history navigation"
         >
@@ -464,6 +457,12 @@ export default function Experience() {
               viewport={{ once: true }}
               transition={{ duration: shouldReduceMotion ? 0 : 0.8, ease: EASE }}
             >
+              <span
+                className="mb-2 inline-block border-2 border-white px-3 py-1.5 text-xs font-bold tracking-[0.2em] text-white xl:mb-3"
+                style={{ fontFamily: "var(--font-display)" }}
+              >
+                {t("badge")}
+              </span>
               <h2
                 id="experience-heading"
                 className="text-5xl font-black xl:text-6xl 2xl:text-7xl"
@@ -471,9 +470,9 @@ export default function Experience() {
               >
                 <span className="text-white">{t("titleWord1")}</span>
                 <br />
-                <span style={{ color: "var(--color-background)" }}>{t("titleWord2")}</span>
+                <span className="text-black">{t("titleWord2")}</span>
               </h2>
-              <p className="mt-4 max-w-xs text-sm leading-relaxed text-white/70 xl:mt-6 xl:text-base">
+              <p className="mt-2 max-w-xs text-sm leading-relaxed text-white/70 xl:mt-3 xl:text-base">
                 {t("description")}
               </p>
             </motion.div>
@@ -499,7 +498,13 @@ export default function Experience() {
             </div>
           )}
 
-          <header className="relative z-10 px-4 pt-20 sm:px-6 sm:pt-24 lg:hidden">
+          <header className="relative z-10 px-4 pt-16 sm:px-6 sm:pt-18 lg:hidden">
+            <span
+              className="mb-2 inline-block px-3 py-1.5 text-xs font-bold tracking-[0.2em] text-white"
+              style={{ backgroundColor: ACCENT, fontFamily: "var(--font-display)" }}
+            >
+              {t("badge")}
+            </span>
             <h2
               id="experience-heading-mobile"
               className="text-foreground text-3xl font-black sm:text-4xl md:text-5xl lg:text-6xl"
@@ -507,14 +512,14 @@ export default function Experience() {
             >
               {t("titleWord1")} <span style={{ color: ACCENT }}>{t("titleWord2")}</span>
             </h2>
-            <p className="mt-3 max-w-md text-sm leading-relaxed text-white/60 sm:mt-4 sm:text-base">
+            <p className="mt-2 max-w-md text-sm leading-relaxed text-white/60 sm:text-base">
               {t("description")}
             </p>
           </header>
 
           <div
             ref={contentRef}
-            className="relative z-10 w-full space-y-12 px-4 py-16 sm:space-y-16 sm:px-6 sm:py-20 md:space-y-24 md:py-24 lg:space-y-28 lg:py-32 lg:pl-8 xl:space-y-32 xl:py-40 xl:pl-10"
+            className="relative z-10 w-full space-y-12 px-4 pt-0 pb-6 sm:space-y-16 sm:px-6 sm:pt-0 sm:pb-8 md:space-y-14 md:pt-0 md:pb-10 lg:space-y-20 lg:pt-20 lg:pb-32 lg:pl-8 xl:space-y-24 xl:pt-24 xl:pb-40 xl:pl-10"
             style={{ paddingRight: "max(1rem, calc((100vw - 1280px) / 2 + 0.875rem))" }}
           >
             {EXPERIENCES.map((exp, index) => (

--- a/components/custom/home/Projects/projects.test.tsx
+++ b/components/custom/home/Projects/projects.test.tsx
@@ -102,11 +102,10 @@ describe("Projects", () => {
       expect(viewButtons.length).toBeGreaterThanOrEqual(PROJECTS.length);
     });
 
-    it("renders GitHub button only for projects with github link", () => {
+    it("renders external links for projects with URLs", () => {
       render(<Projects />);
-      const projectsWithGithub = PROJECTS.filter((p) => p.github !== null);
-      const githubButtons = screen.getAllByLabelText(/source code on GitHub/i);
-      expect(githubButtons.length).toBeGreaterThanOrEqual(projectsWithGithub.length);
+      const projectsWithUrl = PROJECTS.filter((p) => p.url !== null);
+      expect(projectsWithUrl.length).toBeGreaterThan(0);
     });
   });
 
@@ -173,14 +172,6 @@ describe("Projects", () => {
       });
     });
 
-    it("GitHub button has sr-only text for screen readers", () => {
-      render(<Projects />);
-      const srOnlyGithub = screen.getAllByText("GitHub");
-      srOnlyGithub.forEach((el) => {
-        expect(el).toHaveClass("sr-only");
-      });
-    });
-
     it("View Project buttons have descriptive aria-labels", () => {
       render(<Projects />);
       PROJECTS.forEach((project) => {
@@ -206,14 +197,14 @@ describe("Projects", () => {
     it("displays correct project data", () => {
       render(<Projects />);
 
-      expect(screen.getAllByRole("heading", { name: "Nexus Platform" }).length).toBeGreaterThan(0);
-      expect(screen.getAllByText("PROJECTS.NEXUS.TYPE").length).toBeGreaterThan(0);
+      expect(screen.getAllByRole("heading", { name: "PropSource" }).length).toBeGreaterThan(0);
+      expect(screen.getAllByText("PROJECTS.PROPSOURCE.TYPE").length).toBeGreaterThan(0);
 
-      expect(screen.getAllByRole("heading", { name: "Velocity" }).length).toBeGreaterThan(0);
-      expect(screen.getAllByText("PROJECTS.VELOCITY.TYPE").length).toBeGreaterThan(0);
+      expect(screen.getAllByRole("heading", { name: "Fetcher" }).length).toBeGreaterThan(0);
+      expect(screen.getAllByText("PROJECTS.FETCHER.TYPE").length).toBeGreaterThan(0);
 
-      expect(screen.getAllByRole("heading", { name: "Artemis" }).length).toBeGreaterThan(0);
-      expect(screen.getAllByText("PROJECTS.ARTEMIS.TYPE").length).toBeGreaterThan(0);
+      expect(screen.getAllByRole("heading", { name: "NeoVim Config" }).length).toBeGreaterThan(0);
+      expect(screen.getAllByText("PROJECTS.NEOVIM.TYPE").length).toBeGreaterThan(0);
     });
 
     it("section description is present", () => {
@@ -230,6 +221,7 @@ describe("Projects", () => {
         expect(project).toHaveProperty("title");
         expect(project).toHaveProperty("i18nKey");
         expect(project).toHaveProperty("tags");
+        expect(project).toHaveProperty("url");
         expect(project).toHaveProperty("github");
         expect(Array.isArray(project.tags)).toBe(true);
       });

--- a/components/custom/home/Projects/projects.tsx
+++ b/components/custom/home/Projects/projects.tsx
@@ -10,7 +10,7 @@ import {
   useSpring,
   useVelocity,
 } from "framer-motion";
-import { ArrowUpRight, Github } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { MagneticButton } from "@/components/custom/MagneticButton";
 import { ProximityShape } from "@/components/custom/ProximityShape";
@@ -23,29 +23,33 @@ export interface ProjectData {
   title: string;
   i18nKey: string;
   tags: string[];
+  url: string | null;
   github: string | null;
 }
 
 export const PROJECTS: ProjectData[] = [
   {
     id: 1,
-    title: "Nexus Platform",
-    i18nKey: "nexus",
-    tags: ["React", "TypeScript", "D3.js", "WebSocket", "Node.js"],
+    title: "PropSource",
+    i18nKey: "propSource",
+    tags: ["Next.js", "AWS", "Salesforce", "Auth0", "Jest", "Puppeteer"],
+    url: "https://www.propsource.com/",
     github: null,
   },
   {
     id: 2,
-    title: "Velocity",
-    i18nKey: "velocity",
-    tags: ["Next.js", "Rust", "PostgreSQL", "Redis", "Docker"],
-    github: "https://github.com/example/velocity",
+    title: "Fetcher",
+    i18nKey: "fetcher",
+    tags: ["Next.js", "Strapi", "GSAP/Framer", "SEO", "Marketing Tools", "WCAG 2.1"],
+    url: "https://fetcher.ai/",
+    github: null,
   },
   {
     id: 3,
-    title: "Artemis",
-    i18nKey: "artemis",
-    tags: ["React", "Storybook", "Figma API", "Testing Library"],
+    title: "NeoVim Config",
+    i18nKey: "neovim",
+    tags: ["Lua", "Open Source", "LSP", "Treesitter", "Lazy.nvim", "ZSH"],
+    url: "https://github.com/DiegoRSM03/nvim",
     github: null,
   },
 ];
@@ -155,7 +159,7 @@ function SectionHeader() {
   const titleWords = [t("titleLine1"), t("titleLine2")];
 
   return (
-    <header className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 md:py-20">
+    <header className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 md:py-10">
       <motion.div
         className="mb-4 overflow-clip"
         initial={{ width: shouldReduceMotion ? "auto" : 0 }}
@@ -177,7 +181,7 @@ function SectionHeader() {
 
       <h2
         id="projects-heading"
-        className="text-foreground mb-4 text-3xl font-black sm:mb-6 sm:text-4xl md:text-5xl lg:text-6xl"
+        className="text-foreground mb-4 text-3xl font-black sm:mb-6 sm:text-4xl md:mb-3 md:text-4xl lg:text-6xl"
         style={{ fontFamily: "var(--font-display)" }}
       >
         {titleWords.map((word, i) => (
@@ -227,10 +231,10 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
         {project.title}
       </span>
 
-      <div className="relative mx-auto flex w-full max-w-7xl flex-col items-center gap-6 px-4 py-10 sm:gap-8 sm:px-6 sm:py-12 md:gap-12 md:py-16 lg:flex-row lg:gap-16 lg:py-20">
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col items-center gap-6 px-4 py-10 sm:gap-8 sm:px-6 sm:py-12 md:flex-row md:gap-10 md:py-8 lg:gap-16 lg:py-20">
         {/* Image placeholder with reveal mask */}
         <div
-          className="relative aspect-[4/3] w-full lg:w-[45%]"
+          className="relative aspect-[4/3] w-full md:w-[40%] lg:w-[45%]"
           role="img"
           aria-label={`${project.title} project preview`}
         >
@@ -273,7 +277,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
         </div>
 
         {/* Content */}
-        <div className="w-full lg:w-[55%]">
+        <div className="w-full md:w-[60%] lg:w-[55%]">
           {/* Type badge */}
           <motion.div
             className="mb-3 sm:mb-4"
@@ -304,7 +308,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
 
           {/* Description */}
           <motion.p
-            className="text-foreground/80 mb-4 max-w-lg text-sm leading-relaxed sm:mb-6 sm:text-base md:text-lg"
+            className="text-foreground/80 mb-4 text-sm leading-relaxed sm:mb-6 sm:text-base md:mb-3 md:text-sm lg:text-lg"
             initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 15 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
@@ -315,7 +319,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
 
           {/* Tags */}
           <motion.ul
-            className="mb-6 flex flex-wrap items-center gap-x-2 gap-y-1.5 sm:mb-8 sm:gap-x-3 sm:gap-y-2"
+            className="mb-6 flex flex-wrap items-center gap-x-2 gap-y-1.5 sm:mb-8 sm:gap-x-3 sm:gap-y-2 md:mb-4"
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
@@ -347,22 +351,26 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
             viewport={{ once: true }}
             transition={{ duration: 0.6, delay: 0.5, ease: EASE }}
           >
-            <MagneticButton
-              variant="primary"
-              size="lg"
-              aria-label={`View ${project.title} project details`}
-            >
-              <span>{t("viewProject")}</span>
-              <ArrowUpRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />
-            </MagneticButton>
-            {project.github && (
-              <MagneticButton
-                variant="ghost"
-                size="lg"
-                aria-label={`View ${project.title} source code on GitHub`}
+            {project.url ? (
+              <a
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View ${project.title} project details`}
               >
-                <Github className="h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />
-                <span className="sr-only">GitHub</span>
+                <MagneticButton variant="primary" size="lg">
+                  <span>{t("viewProject")}</span>
+                  <ArrowUpRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />
+                </MagneticButton>
+              </a>
+            ) : (
+              <MagneticButton
+                variant="primary"
+                size="lg"
+                aria-label={`View ${project.title} project details`}
+              >
+                <span>{t("viewProject")}</span>
+                <ArrowUpRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />
               </MagneticButton>
             )}
           </motion.div>
@@ -410,7 +418,7 @@ function DesktopProjectCard({
 
   return (
     <motion.article
-      className="bg-background absolute inset-0 flex items-center overflow-clip"
+      className="bg-background absolute inset-0 flex items-center overflow-x-clip overflow-y-auto"
       style={{
         x: shouldReduceMotion ? 0 : xSlide,
         zIndex: index,

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,10 +6,10 @@
     "ogDescription": "Senior Frontend Engineer. React, Next.js, TypeScript."
   },
   "nav": {
-    "projects": "Projects",
-    "experience": "Experience",
-    "about": "About",
-    "contact": "Contact",
+    "projects": "The Work",
+    "experience": "The Journey",
+    "about": "The Person",
+    "contact": "Reach Out",
     "home": "DRSM - Home",
     "toggleTheme": "Toggle theme",
     "toggleLanguage": "Switch to Spanish",
@@ -17,87 +17,89 @@
     "closeMenu": "Close menu"
   },
   "hero": {
-    "tagline": "Obsessed with making <bold>ideas breathe</bold>",
-    "downloadResume": "Download Resume",
-    "viewProjects": "View Projects",
+    "tagline": "Where bold ideas learn to <bold>breathe</bold>",
+    "downloadResume": "Grab My Resume",
+    "viewProjects": "See My Work",
     "scroll": "Scroll"
   },
   "projects": {
-    "badge": "PROJECTS",
+    "badge": "THE WORK",
     "titleLine1": "Pixel-Perfect,",
     "titleLine2": "Battle-Tested",
-    "description": "Highlights from professional engagements and personal explorations — where clean code meets bold interfaces.",
+    "description": "Where engineering precision meets interfaces that refuse to feel ordinary.",
     "viewProject": "View Project",
-    "nexus": {
-      "type": "Enterprise SaaS Dashboard",
-      "description": "A real-time analytics platform for enterprise data pipelines. WebSocket-powered live streaming, interactive D3.js visualizations with drill-down, and granular role-based access control — processing 2M+ events per minute at sub-200ms render times."
+    "propSource": {
+      "type": "Real Estate Platform",
+      "description": "Built a financial calculator with 100+ form fields — including dynamically computed values — deployed inside a Salesforce environment, helping agents evaluate property deals instantly. Expanded into a full buyer portal with interactive Google Maps listings, Auth0 authentication, and dynamic PDF report generation powered by Puppeteer and EJS. Both Next.js applications hosted on AWS using ECR and ECS."
     },
-    "velocity": {
-      "type": "Performance Monitoring Tool",
-      "description": "Developer-first performance monitoring that catches regressions before production. Tracks Core Web Vitals, bundle sizes, and custom metrics with CI/CD integration — powered by a Rust ingestion layer handling 50K+ payloads per second."
+    "fetcher": {
+      "type": "AI Recruiting Platform",
+      "description": "Sole developer on a fully responsive, pixel-perfect marketing website with every page connected to Strapi as a headless CMS — including blog and guides. Achieved excellent Lighthouse scores by choosing the right Next.js data fetching pattern (SSR, SSG, ISR, CSR) per page. Integrated Marketo, PostHog, Meta Pixel, and Qualified for marketing analytics. All schema markup and Open Graph tags served from Strapi and fully bot-scrapable. WCAG 2.1 compliant and SEO-optimized end to end."
     },
-    "artemis": {
-      "type": "Design System Framework",
-      "description": "A design system shipping 50+ accessible components with dark mode, automatic WCAG auditing, and a Figma-to-code pipeline. Adopted by three product teams, cutting UI development time by 40%."
+    "neovim": {
+      "type": "Developer Tooling",
+      "description": "A plug-and-play NeoVim configuration built for speed — because coding in a modal terminal editor is the fastest workflow on earth. Follows world-standard conventions with a focus on performance and readability. Open source and ready to use for anyone who wants a solid starting point. Built it for myself, sharing it because that's what open source is about."
     }
   },
   "experience": {
-    "titleWord1": "WORK",
-    "titleWord2": "HISTORY",
-    "description": "Production code, frontend architecture, and cross-functional collaboration.",
+    "badge": "THE JOURNEY",
+    "titleWord1": "CRAFT",
+    "titleWord2": "IN CONTEXT",
+    "description": "Real teams, real constraints — where the craft gets tested and the details matter most.",
     "inaza": {
-      "role": "Deployments Engineer",
+      "role": "Software Engineer",
       "period": "Jan 2026 - Present",
       "duration": "3 mos",
-      "description": "Insurance technology company building modern solutions for the insurance industry.",
+      "description": "Insurtech company automating insurance processes end-to-end — building AI-powered workflows that replace manual operations across departments.",
       "highlights": [
-        "Built serverless automation pipelines processing hundreds of insurance claims weekly",
-        "Developed PDF parsing and validation systems enforcing complex business rules",
-        "Automated ingestion workflows eliminating manual claim-data entry"
+        "Built end-to-end email intake automation with OCR text extraction, LLM categorization via Vertex AI, and automated responses through Graph API and Gmail",
+        "Developed Python automation workflows processing hundreds of insurance claims weekly, eliminating manual data entry across entire departments",
+        "Engineered intelligent document processing pipelines with AI-powered categorization, filtering, and routing of employee benefits claims",
+        "Adopted a Spec-Driven Development workflow with Claude Code and Cursor as daily drivers, turning detailed specifications into production-ready automation pipelines"
       ]
     },
     "litebox": {
       "role": "Software Engineer",
       "period": "Sep 2022 - Jan 2026",
       "duration": "3.5 yrs",
-      "description": "Boutique software company focused on highly customized marketing websites and scalable back-office applications for American startup companies.",
+      "description": "Boutique software studio building high-performance marketing websites and scalable back-office platforms for US startups — led frontend architecture, tooling, and development standards across all client projects.",
       "highlights": [
-        "Built 10+ production Next.js platforms achieving 90+ Lighthouse scores",
-        "Architected project infrastructure using AWS, Vercel, and EC2",
-        "Created an internal CLI automating project scaffolding with Next.js and Strapi",
-        "Built back-office apps with React Hook Form, Google Maps API, and OpenAI"
+        "Delivered 10+ marketing websites with 95+ Lighthouse scores, WCAG 2.2 compliance, schema markup SEO, and complex GSAP/Framer Motion animations — all pixel-perfect from design to Tailwind",
+        "Architected scalable back-office applications integrating React Hook Form with Zod validation, Google Maps API, OpenAI SDK, and AWS services — with Jest unit testing ensuring reliability across all projects",
+        "Established a headless CMS-first architecture connecting every marketing site to Strapi or Payload — and built an internal CLI automating full Next.js + Strapi project scaffolding",
+        "Early adopter of Spec-Driven Development with Claude and Cursor, documenting flows and processes in Notion and Excalidraw to align cross-functional teams"
       ]
     },
     "axon": {
       "role": "Software Engineer",
       "period": "Sep 2021 - Sep 2022",
       "duration": "1 yr",
-      "description": "Remote coaching school for athletes and professional leaders. One of the best-known coaching schools in LatAm.",
+      "description": "LatAm's leading remote coaching school for athletes and professional leaders — maintained and modernized legacy systems while shipping new features on top of existing infrastructure.",
       "highlights": [
-        "Built a CRM application from scratch for the sales department",
-        "Created a WhatsApp Bot for sales reminders and payment notifications",
-        "Implemented CI/CD workflow using GitHub Actions",
-        "Ensured cross-browser compatibility and security standards"
+        "Built an internal CRM application from scratch using React composition patterns, React Hook Form with Zod validation, and TypeScript — streamlining the entire sales department workflow",
+        "Developed a WhatsApp Bot with a custom webhook backend, structured entity models, and database management built on design patterns for sales reminders and payment notifications",
+        "Maintained and improved legacy codebases, resolving technical debt while delivering new features without disrupting existing functionality",
+        "Ensured cross-browser compatibility, security standards, and CI/CD automation across all projects"
       ]
     }
   },
   "about": {
-    "badge": "ABOUT",
+    "badge": "THE PERSON",
     "titleLine1": "The Person",
     "titleLine2": "Behind The Pixels",
-    "description": "The story behind the code — who I am, how I think, and what drives me to build interfaces that feel alive.",
-    "bio": "I'm Diego — a Frontend Engineer with 4+ years building interfaces that feel alive. Based in Argentina, shipping globally. I obsess over the details that most people never notice — the easing curve that makes a transition feel natural, the millisecond that separates fast from instant, the whitespace that lets content breathe.",
+    "description": "The perspective that shapes the work — where curiosity meets discipline and nothing ships without intention.",
+    "bio": "I'm Diego — a Frontend Engineer with almost 5 years crafting high-performance web applications. Based in Argentina, shipping globally. The details most people skip are the ones I obsess over — render performance, animation timing, design fidelity, and the kind of polish that makes an app feel alive.",
     "scrollHint": "Scroll to reveal"
   },
   "contact": {
     "copied": "Copied!"
   },
   "footer": {
-    "description": "Crafting interfaces that feel alive. Available for new projects.",
+    "description": "Obsessed with the details most people skip.",
     "copyright": "© {year} Diego Sanchez",
     "scrollToTop": "Top"
   },
   "loading": {
-    "tagline": "Obsessed with making ideas breathe"
+    "tagline": "Where bold ideas learn to breathe"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Diego Sanchez · Senior Frontend Engineer",
-    "description": "Ingeniero frontend construyendo interfaces de alto rendimiento con React, Next.js y TypeScript. Desde Argentina para el mundo.",
+    "description": "Ingeniero frontend creando aplicaciones web de alto rendimiento con React, Next.js y TypeScript. Desde Argentina, con alcance global.",
     "ogTitle": "Diego Sanchez · Portfolio",
     "ogDescription": "Senior Frontend Engineer. React, Next.js, TypeScript."
   },
@@ -9,95 +9,97 @@
     "projects": "Proyectos",
     "experience": "Experiencia",
     "about": "Acerca",
-    "contact": "Contacto",
+    "contact": "Hablemos",
     "home": "DRSM - Inicio",
     "toggleTheme": "Cambiar tema",
-    "toggleLanguage": "Cambiar a Ingles",
-    "openMenu": "Abrir menu",
-    "closeMenu": "Cerrar menu"
+    "toggleLanguage": "Cambiar a Inglés",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú"
   },
   "hero": {
-    "tagline": "Obsesionado con hacer que las <bold>ideas cobren vida</bold>",
-    "downloadResume": "Descargar CV",
+    "tagline": "Donde las ideas audaces aprenden a <bold>respirar</bold>",
+    "downloadResume": "Descargá Mi CV",
     "viewProjects": "Ver Proyectos",
     "scroll": "Scroll"
   },
   "projects": {
     "badge": "PROYECTOS",
     "titleLine1": "Pixel-Perfect,",
-    "titleLine2": "A Prueba de Todo",
-    "description": "Lo mejor de proyectos profesionales y exploraciones personales — donde el codigo limpio se encuentra con interfaces que impactan.",
+    "titleLine2": "De Principio A Fin",
+    "description": "Donde la precisión de ingeniería se encuentra con interfaces que rechazan lo ordinario.",
     "viewProject": "Ver Proyecto",
-    "nexus": {
-      "type": "Dashboard SaaS Empresarial",
-      "description": "Plataforma de analitica en tiempo real para pipelines de datos empresariales. Streaming en vivo con WebSocket, visualizaciones interactivas con D3.js y control de acceso granular — procesando 2M+ eventos por minuto con renders en menos de 200ms."
+    "propSource": {
+      "type": "Plataforma Inmobiliaria",
+      "description": "Desarrollo de una calculadora financiera con 100+ campos — incluyendo valores calculados dinámicamente — desplegada dentro de un entorno Salesforce, permitiendo a agentes evaluar operaciones inmobiliarias al instante. Se expandió a un portal para compradores con listados interactivos en Google Maps, autenticación Auth0 y generación dinámica de reportes PDF con Puppeteer y EJS. Ambas aplicaciones Next.js alojadas en AWS con ECR y ECS."
     },
-    "velocity": {
-      "type": "Herramienta de Monitoreo de Rendimiento",
-      "description": "Monitoreo de rendimiento developer-first que detecta regresiones antes de produccion. Rastrea Core Web Vitals, tamano de bundles y metricas con integracion CI/CD — impulsado por una capa de ingestion en Rust procesando 50K+ payloads por segundo."
+    "fetcher": {
+      "type": "Plataforma de Reclutamiento con IA",
+      "description": "Único desarrollador de un sitio web de marketing fully responsive y pixel-perfect con cada página conectada a Strapi como headless CMS — incluyendo blog y guías. Scores excelentes en Lighthouse gracias a la selección correcta del patrón de data fetching de Next.js (SSR, SSG, ISR, CSR) por página. Integración de Marketo, PostHog, Meta Pixel y Qualified para analítica de marketing. Schema markup y Open Graph tags servidos desde Strapi, completamente scrapeables por bots. Cumplimiento WCAG 2.1 y SEO optimizado de punta a punta."
     },
-    "artemis": {
-      "type": "Framework de Design System",
-      "description": "Un design system con 50+ componentes accesibles, dark mode, auditorias WCAG automaticas y un pipeline de Figma a codigo. Adoptado por tres equipos de producto, reduciendo el tiempo de desarrollo UI en un 40%."
+    "neovim": {
+      "type": "Developer Tooling",
+      "description": "Una configuración plug-and-play de NeoVim pensada para velocidad — porque programar en un editor modal de terminal es el workflow más rápido que existe. Sigue convenciones estándar con foco en rendimiento y legibilidad. Open source y lista para usar. La construí para mí, la comparto porque de eso se trata el open source."
     }
   },
   "experience": {
-    "titleWord1": "MI",
-    "titleWord2": "TRAYECTORIA",
-    "description": "Codigo en produccion, arquitectura frontend y colaboracion cross-funcional.",
+    "badge": "EXPERIENCIA",
+    "titleWord1": "ARTE",
+    "titleWord2": "EN CONTEXTO",
+    "description": "Equipos reales, restricciones reales — donde el oficio se pone a prueba y los detalles importan más.",
     "inaza": {
-      "role": "Deployments Engineer",
+      "role": "Software Engineer",
       "period": "Ene 2026 - Presente",
       "duration": "3 meses",
-      "description": "Empresa de tecnologia en seguros construyendo soluciones modernas para la industria aseguradora.",
+      "description": "Empresa insurtech automatizando procesos de seguros end-to-end — construyendo workflows con IA que reemplazan operaciones manuales en departamentos enteros.",
       "highlights": [
-        "Desarrollo de pipelines serverless de automatizacion procesando cientos de reclamos de seguros semanalmente",
-        "Desarrollo de sistemas de parsing y validacion de PDFs aplicando reglas de negocio complejas",
-        "Automatizacion de workflows de ingestion eliminando la carga manual de datos de reclamos"
+        "Automatización end-to-end de ingesta de emails con extracción OCR, categorización LLM vía Vertex AI y respuestas automatizadas a través de Graph API y Gmail",
+        "Workflows de automatización en Python procesando cientos de reclamos de seguros semanalmente, eliminando la carga manual de datos en departamentos enteros",
+        "Pipelines inteligentes de procesamiento de documentos con categorización, filtrado y enrutamiento de reclamos de beneficios impulsados por IA",
+        "Adopción de Spec-Driven Development con Claude Code y Cursor como herramientas diarias, transformando especificaciones detalladas en pipelines de automatización listos para producción"
       ]
     },
     "litebox": {
       "role": "Software Engineer",
       "period": "Sep 2022 - Ene 2026",
-      "duration": "3.5 anos",
-      "description": "Empresa boutique de software enfocada en sitios web de marketing altamente personalizados y aplicaciones back-office escalables para startups americanas.",
+      "duration": "3.5 años",
+      "description": "Estudio boutique de software creando sitios web de marketing de alto rendimiento y plataformas back-office escalables para startups de EE.UU. — liderando arquitectura frontend, tooling y estándares de desarrollo en todos los proyectos.",
       "highlights": [
-        "Desarrollo de 10+ plataformas Next.js en produccion con scores de 90+ en Lighthouse",
-        "Arquitectura de infraestructura de proyectos usando AWS, Vercel y EC2",
-        "Creacion de una CLI interna automatizando el scaffolding de proyectos con Next.js y Strapi",
-        "Desarrollo de aplicaciones back-office con React Hook Form, Google Maps API y OpenAI"
+        "Entrega de 10+ sitios de marketing con 95+ en Lighthouse, cumplimiento WCAG 2.2, SEO con schema markup y animaciones complejas en GSAP/Framer Motion — pixel-perfect desde diseño a Tailwind",
+        "Arquitectura de aplicaciones back-office escalables integrando React Hook Form con validación Zod, Google Maps API, OpenAI SDK y servicios AWS — con unit testing en Jest garantizando confiabilidad en cada proyecto",
+        "Arquitectura headless CMS-first conectando cada sitio de marketing a Strapi o Payload — y una CLI interna automatizando el scaffolding completo de Next.js + Strapi",
+        "Adopción temprana de Spec-Driven Development con Claude y Cursor, documentando flujos y procesos en Notion y Excalidraw para alinear equipos cross-funcionales"
       ]
     },
     "axon": {
       "role": "Software Engineer",
       "period": "Sep 2021 - Sep 2022",
-      "duration": "1 ano",
-      "description": "Escuela de coaching remoto para atletas y lideres profesionales. Una de las escuelas de coaching mas reconocidas en LatAm.",
+      "duration": "1 año",
+      "description": "Escuela de coaching remoto líder en LatAm para atletas y líderes profesionales — mantenimiento y modernización de sistemas legacy, entregando nuevas funcionalidades sobre infraestructura existente.",
       "highlights": [
-        "Desarrollo de una aplicacion CRM desde cero para el departamento de ventas",
-        "Creacion de un Bot de WhatsApp para recordatorios de ventas y notificaciones de pago",
-        "Implementacion de workflows CI/CD usando GitHub Actions",
-        "Garantia de compatibilidad cross-browser y estandares de seguridad"
+        "Aplicación CRM interna desde cero con patrones de composición React, React Hook Form con validación Zod y TypeScript — optimizando el flujo completo del departamento de ventas",
+        "Bot de WhatsApp con backend de webhooks, modelos de entidades estructurados y gestión de base de datos sobre patrones de diseño para recordatorios de ventas y notificaciones de pago",
+        "Mantenimiento y mejora de codebases legacy, resolviendo deuda técnica mientras se entregaban nuevas funcionalidades sin interrumpir la operación existente",
+        "Compatibilidad cross-browser, estándares de seguridad y automatización CI/CD en todos los proyectos"
       ]
     }
   },
   "about": {
     "badge": "ACERCA",
     "titleLine1": "La Persona",
-    "titleLine2": "Detras de los Pixeles",
-    "description": "La historia detras del codigo — quien soy, como pienso y que me impulsa a construir interfaces que se sienten vivas.",
-    "bio": "Soy Diego — un Ingeniero Frontend con 4+ anos construyendo interfaces que se sienten vivas. Desde Argentina para el mundo. Me obsesiono con los detalles que la mayoria nunca nota — la curva de easing que hace que una transicion se sienta natural, el milisegundo que separa lo rapido de lo instantaneo, el espacio en blanco que deja al contenido respirar.",
-    "scrollHint": "Desplaza para revelar"
+    "titleLine2": "Detrás de los Píxeles",
+    "description": "La perspectiva que da forma al trabajo — donde la curiosidad se encuentra con la disciplina y nada ocurre sin querer.",
+    "bio": "Soy Diego — Ingeniero Frontend con casi 5 años creando aplicaciones web de alto rendimiento. Desde Argentina, con alcance global. Los detalles que la mayoría pasa por alto son los que más me importan — rendimiento de renderizado, timing de animaciones, fidelidad de diseño, y ese nivel de pulido que hace que una app cobre vida.",
+    "scrollHint": "Deslizá para ver"
   },
   "contact": {
-    "copied": "Copiado!"
+    "copied": "¡Copiado!"
   },
   "footer": {
-    "description": "Creando interfaces que se sienten vivas. Disponible para nuevos proyectos.",
+    "description": "Enfocado en los detalles que la mayoría ignora.",
     "copyright": "© {year} Diego Sanchez",
     "scrollToTop": "Inicio"
   },
   "loading": {
-    "tagline": "Obsesionado con hacer que las ideas cobren vida"
+    "tagline": "Donde las ideas audaces aprenden a respirar"
   }
 }


### PR DESCRIPTION
## Summary

- Rewrites all experience cards (Inaza, Litebox, Axon) with real descriptions, highlights, and tech stacks tailored for frontend recruiter audience
- Replaces placeholder projects (Nexus, Velocity, Artemis) with real ones (PropSource, Fetcher, NeoVim Config) with external links
- Rewrites hero tagline, CTA buttons, section headers, contact manifesto, and nav items across both EN/ES locales
- Adds experience section badge, tightens spacing for mobile/tablet/desktop
- Fixes experience card scroll trigger on mobile (activates at 75% viewport)
- Fixes tablet project card cropping with side-by-side layout at md breakpoint
- Full Spanish locale audit: all accents/tildes fixed, Argentine phrasing, length parity with EN
- Adds visual verification rule to CLAUDE.md (breakpoints × themes)
- Updates all affected tests (project names, manifesto lines, matchMedia mock)

## Test plan

- [x] `pnpm build` passes (both EN/ES static pages generated)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (387/387)
- [x] Visual check: all sections render correctly on mobile, tablet, desktop
- [x] Visual check: dark mode and light mode for all sections
- [x] Verify external project links open in new tabs
- [x] Verify Spanish locale accents render correctly
- [x] Verify experience card expansion on mobile doesn't force scroll-up