### PR TITLE
fix: scroll lock after nav clicks and About title spacing

### DIFF
--- a/components/common/Footer/footer.tsx
+++ b/components/common/Footer/footer.tsx
@@ -84,6 +84,18 @@ function Footer() {
               <a
                 key={key}
                 href={`#${key}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  const target = document.getElementById(key);
+                  if (target) {
+                    const top = target.getBoundingClientRect().top + window.scrollY - 80;
+                    if (lenis) {
+                      lenis.scrollTo(top, { duration: 1.2 });
+                    } else {
+                      window.scrollTo({ top, behavior: "smooth" });
+                    }
+                  }
+                }}
                 className="focus-visible:ring-offset-accent text-sm font-medium text-white/70 transition-colors duration-200 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:outline-none"
               >
                 {tNav(key)}

--- a/components/common/Navbar/navbar.tsx
+++ b/components/common/Navbar/navbar.tsx
@@ -16,6 +16,7 @@ import { useRouter, usePathname, Link } from "@/i18n/routing";
 import { ThemeToggle } from "@/components/custom/ThemeToggle";
 import { useTheme } from "@/contexts";
 import { useIsTouchDevice } from "@/hooks";
+import { useLenis } from "@/components/custom/LenisProvider";
 
 const EASE = [0.22, 1, 0.36, 1] as const;
 const NAV_KEYS = ["projects", "experience", "about", "contact"] as const;
@@ -822,7 +823,7 @@ interface MagneticNavLinkProps {
   focusedIndex: number | null;
   onHover: (i: number | null) => void;
   onFocus: (i: number | null) => void;
-  onClose: () => void;
+  onClose: (navKey: string) => void;
 }
 
 function MagneticNavLink({
@@ -875,7 +876,10 @@ function MagneticNavLink({
         href={`#${navKey}`}
         className="group relative block cursor-pointer focus-visible:outline-none"
         style={{ x: enableMotion ? springX : 0, y: enableMotion ? springY : 0 }}
-        onClick={onClose}
+        onClick={(e) => {
+          e.preventDefault();
+          onClose(navKey);
+        }}
         onFocus={() => onFocus(index)}
         onBlur={() => onFocus(null)}
       >
@@ -911,7 +915,7 @@ function MagneticNavLink({
 // Curtain content
 // ─────────────────────────────────────────────
 
-function CurtainContent({ onClose }: { onClose: () => void }) {
+function CurtainContent({ onClose }: { onClose: (navKey: string) => void }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
   const shouldReduceMotion = useReducedMotion();
@@ -971,6 +975,7 @@ function Navbar({ className }: NavbarProps) {
   const [scrolled, setScrolled] = useState(false);
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
   const shouldReduceMotion = useReducedMotion();
+  const { lenis } = useLenis();
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50);
@@ -992,24 +997,47 @@ function Navbar({ className }: NavbarProps) {
         document.body.style.paddingRight = "";
         setScrollbarWidth(0);
         setIsOpen(false);
+        lenis?.start();
       }
     };
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
-  }, [isOpen]);
+  }, [isOpen, lenis]);
+
+  const openMenu = () => {
+    const width = window.innerWidth - document.documentElement.clientWidth;
+    setScrollbarWidth(width);
+    document.body.style.overflow = "hidden";
+    document.body.style.paddingRight = `${width}px`;
+    lenis?.stop();
+    setIsOpen(true);
+  };
+
+  const closeMenu = (scrollToKey?: string) => {
+    document.body.style.overflow = "";
+    document.body.style.paddingRight = "";
+    setScrollbarWidth(0);
+    setIsOpen(false);
+    lenis?.start();
+
+    if (scrollToKey) {
+      const target = document.getElementById(scrollToKey);
+      if (target) {
+        const top = target.getBoundingClientRect().top + window.scrollY - 80;
+        if (lenis) {
+          lenis.scrollTo(top, { duration: 1.2 });
+        } else {
+          window.scrollTo({ top, behavior: "smooth" });
+        }
+      }
+    }
+  };
 
   const handleMenuToggle = () => {
     if (!isOpen) {
-      const width = window.innerWidth - document.documentElement.clientWidth;
-      setScrollbarWidth(width);
-      document.body.style.overflow = "hidden";
-      document.body.style.paddingRight = `${width}px`;
-      setIsOpen(true);
+      openMenu();
     } else {
-      document.body.style.overflow = "";
-      document.body.style.paddingRight = "";
-      setScrollbarWidth(0);
-      setIsOpen(false);
+      closeMenu();
     }
   };
 
@@ -1059,7 +1087,7 @@ function Navbar({ className }: NavbarProps) {
             aria-modal="true"
             aria-label="Navigation menu"
           >
-            <CurtainContent onClose={() => setIsOpen(false)} />
+            <CurtainContent onClose={closeMenu} />
           </motion.div>
         )}
       </AnimatePresence>

--- a/components/custom/home/About/about.tsx
+++ b/components/custom/home/About/about.tsx
@@ -64,7 +64,9 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
           {titleWords.map((word, i) => (
             <span
               key={i}
-              className={`inline-block overflow-clip${i === 0 ? "mr-2 sm:mr-3 md:mr-4" : ""}`}
+              className={["inline-block overflow-clip", i === 0 && "mr-2 sm:mr-3 md:mr-4"]
+                .filter(Boolean)
+                .join(" ")}
             >
               <motion.span
                 className="inline-block"
@@ -75,7 +77,7 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
               >
                 {word}
               </motion.span>
-              {i === 0 && <br className="sm:hidden" />}
+              {i === 0 && <br className="md:hidden" />}
             </span>
           ))}
         </h2>


### PR DESCRIPTION
## Summary

- **Fix scroll breaking on mobile/tablet after clicking internal links** — Navbar curtain and footer anchor links used native hash navigation (`<a href="#section">`) which desynchronized Lenis smooth scroll state, preventing all further scrolling/swiping. All internal links now use `e.preventDefault()` + `lenis.scrollTo()`. Lenis is properly stopped when the curtain opens and restarted when it closes (including Escape key dismiss).
- **Fix About section title spacing** — Missing space in className concatenation caused `overflow-clipmr-2` instead of `overflow-clip mr-2`. Also extended the line break between "The Person" / "Behind The Pixels" through tablet (`md:hidden` instead of `sm:hidden`) so it only goes inline at 768px+ where there's enough room.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 389 tests passing
- [x] `pnpm build` — static export succeeds
- [x] Mobile: tap navbar curtain links → page scrolls to section, swiping still works
- [x] Tablet: tap navbar curtain links → same behavior
- [x] Mobile/tablet: About title shows proper spacing between lines
- [x] Footer links scroll to correct sections without breaking scroll
- [x] Escape key closes curtain and restores scrolling