### PR TITLE
feat: fix LCP render delay with CSS-driven Hero animations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -170,6 +170,73 @@ body {
   z-index: 1;
 }
 
+/* Hero entrance animations — CSS-driven so LCP text is visible before JS hydrates */
+@keyframes hero-slide-up {
+  from {
+    transform: translateY(50px);
+  }
+}
+
+@keyframes hero-slide-up-sm {
+  from {
+    transform: translateY(20px);
+  }
+}
+
+@keyframes hero-scale-x {
+  from {
+    transform: scaleX(0);
+  }
+}
+
+@keyframes hero-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+.hero-title-1 {
+  animation: hero-slide-up 0.8s var(--ease-out) 0.8s both;
+}
+
+.hero-title-2 {
+  animation: hero-slide-up 0.8s var(--ease-out) 0.9s both;
+}
+
+.hero-accent-bar {
+  transform-origin: left;
+  animation: hero-scale-x 0.6s var(--ease-out) 1.2s both;
+}
+
+.hero-tagline {
+  animation:
+    hero-slide-up-sm 0.6s var(--ease-out) 1.6s both,
+    hero-fade-in 0.1s linear 1.6s both;
+}
+
+.hero-cta {
+  animation:
+    hero-slide-up-sm 0.6s var(--ease-out) 1.8s both,
+    hero-fade-in 0.1s linear 1.8s both;
+}
+
+.hero-pills {
+  animation:
+    hero-slide-up-sm 0.6s var(--ease-out) 0.5s both,
+    hero-fade-in 0.1s linear 0.5s both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-title-1,
+  .hero-title-2,
+  .hero-accent-bar,
+  .hero-tagline,
+  .hero-cta,
+  .hero-pills {
+    animation: none;
+  }
+}
+
 /* Skeleton shimmer animation */
 @keyframes shimmer {
   100% {

--- a/components/custom/home/Hero/hero.tsx
+++ b/components/custom/home/Hero/hero.tsx
@@ -15,7 +15,7 @@ import { SiReact, SiTypescript, SiNextdotjs, SiTailwindcss, SiJest } from "react
 import { useTranslations } from "next-intl";
 import { MagneticButton } from "@/components/custom/MagneticButton";
 import { ProximityShape } from "@/components/custom/ProximityShape";
-import { ACCENT, CYAN_HEX, PINK_HEX, AMBER_HEX, GREEN_HEX, EASE } from "@/utils";
+import { ACCENT, CYAN_HEX, PINK_HEX, AMBER_HEX, GREEN_HEX } from "@/utils";
 import { useIsTouchDevice } from "@/hooks";
 import { GridBackground } from "@/components/custom/GridBackground";
 import { CursorBrightGrid } from "@/components/custom/CursorEffects";
@@ -214,14 +214,8 @@ function Hero() {
         style={{ y: y1 }}
       >
         <motion.div
-          className="mb-8 flex flex-wrap justify-center gap-3"
+          className="hero-pills mb-8 flex flex-wrap justify-center gap-3"
           style={{ y: y2 }}
-          initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            delay: shouldReduceMotion ? 0 : 0.5,
-            duration: shouldReduceMotion ? 0 : 0.6,
-          }}
           role="list"
           aria-label="Technology stack"
         >
@@ -237,72 +231,37 @@ function Hero() {
         </motion.div>
 
         <motion.div style={{ y: y3 }}>
-          <motion.h1
-            className="text-foreground mb-2 text-6xl font-black tracking-tight sm:text-7xl md:text-8xl lg:text-9xl"
+          <h1
+            className="hero-title-1 text-foreground mb-2 text-6xl font-black tracking-tight sm:text-7xl md:text-8xl lg:text-9xl"
             style={{ fontFamily: "var(--font-display)" }}
-            initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 50 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              delay: shouldReduceMotion ? 0 : 0.8,
-              duration: shouldReduceMotion ? 0 : 0.8,
-              ease: EASE,
-            }}
           >
             DIEGO
-          </motion.h1>
-          <motion.h1
-            className="mb-6 text-6xl font-black tracking-tight sm:text-7xl md:text-8xl lg:text-9xl"
+          </h1>
+          <h1
+            className="hero-title-2 mb-6 text-6xl font-black tracking-tight sm:text-7xl md:text-8xl lg:text-9xl"
             style={{ fontFamily: "var(--font-display)" }}
-            initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 50 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              delay: shouldReduceMotion ? 0 : 0.9,
-              duration: shouldReduceMotion ? 0 : 0.8,
-              ease: EASE,
-            }}
             aria-label="Sanchez"
           >
             <span className="relative inline-block">
               <span className="text-background relative z-10">SANCHEZ</span>
-              <motion.span
-                className="bg-accent absolute -inset-x-4 inset-y-0"
-                initial={{ scaleX: shouldReduceMotion ? 1 : 0, originX: 0 }}
-                animate={{ scaleX: 1 }}
-                transition={{
-                  delay: shouldReduceMotion ? 0 : 1.2,
-                  duration: shouldReduceMotion ? 0 : 0.6,
-                  ease: EASE,
-                }}
+              <span
+                className="hero-accent-bar bg-accent absolute -inset-x-4 inset-y-0"
                 aria-hidden="true"
               />
             </span>
-          </motion.h1>
+          </h1>
         </motion.div>
 
-        <motion.p
-          className="text-foreground/80 mb-12 max-w-lg text-xl md:text-2xl md:whitespace-nowrap"
+        <p
+          className="hero-tagline text-foreground/80 mb-12 max-w-lg text-xl md:text-2xl md:whitespace-nowrap"
           style={{ fontFamily: "var(--font-display)" }}
-          initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            delay: shouldReduceMotion ? 0 : 1.6,
-            duration: shouldReduceMotion ? 0 : 0.6,
-          }}
         >
           {t.rich("tagline", {
             bold: (chunks) => <span className="text-foreground font-bold">{chunks}</span>,
           })}
-        </motion.p>
+        </p>
 
-        <motion.div
-          className="flex flex-wrap items-center justify-center gap-4"
-          initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            delay: shouldReduceMotion ? 0 : 1.8,
-            duration: shouldReduceMotion ? 0 : 0.6,
-          }}
-        >
+        <div className="hero-cta flex flex-wrap items-center justify-center gap-4">
           <a href="/diego-sanchez-resume.pdf" download>
             <MagneticButton variant="primary" size="lg">
               <Download className="mr-2 h-5 w-5" aria-hidden="true" />
@@ -329,7 +288,7 @@ function Hero() {
               <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
             </MagneticButton>
           </a>
-        </motion.div>
+        </div>
       </motion.div>
 
       <motion.div

--- a/spec/06-performance-optimization.md
+++ b/spec/06-performance-optimization.md
@@ -1,0 +1,101 @@
+# Performance Optimization Spec
+
+Target: Lighthouse performance score 95+ on mobile.
+
+## Results (localhost)
+
+| Metric            | Before  | After            |
+| ----------------- | ------- | ---------------- |
+| Performance score | 85      | **91** (+6)      |
+| LCP               | 4.3s    | **3.5s** (-0.8s) |
+| LCP render delay  | 3,030ms | **132ms** (-96%) |
+| TBT               | 60ms    | **30ms**         |
+| Speed Index       | 2.3s    | 2.3s             |
+| FCP               | 0.9s    | 0.9s             |
+
+Key change: Hero headings and tagline use CSS `@keyframes` animations instead of framer-motion `motion.h1`. LCP text ("SANCHEZ") is visible at `opacity: 1` in SSR HTML — no JS hydration needed to paint.
+
+## Production Baseline (2026-03-19)
+
+| Metric      | Value | Score  | Target  |
+| ----------- | ----- | ------ | ------- |
+| FCP         | 2.0s  | yellow | < 1.8s  |
+| LCP         | 3.4s  | yellow | < 2.5s  |
+| Speed Index | 6.3s  | red    | < 3.4s  |
+| TBT         | 40ms  | green  | < 200ms |
+| CLS         | 0     | green  | < 0.1   |
+
+## Root Cause
+
+LCP element is `<span class="text-background relative z-10">SANCHEZ</span>` in the Hero heading. LCP breakdown shows **3,030ms element render delay** — the text exists in SSR HTML but is invisible because framer-motion sets `initial={{ opacity: 0, y: 50 }}`, meaning the text only appears after JS hydrates and runs the entrance animation.
+
+Two JS chunks dominate execution:
+
+- `d2f170b530...js` (framer-motion): 1,165ms eval
+- `0497d1ed27...js` (page bundle): 533ms eval
+
+---
+
+## Phase 1: Fix LCP render delay
+
+The Hero heading ("DIEGO" / "SANCHEZ") uses `motion.h1` with `initial={{ opacity: 0 }}`. SSR renders the HTML with inline `opacity: 0`, so the browser sees the text but can't paint it as LCP until React hydrates and framer-motion triggers the animation.
+
+### 1.1 Make Hero heading visible on SSR
+
+- [ ] Replace `motion.h1` for the two heading lines with plain `<h1>` elements
+- [ ] Use CSS animations (`@keyframes`) for the entrance effect instead of framer-motion
+- [ ] The headings render at `opacity: 1` in the SSR HTML — browser can paint LCP immediately
+- [ ] CSS animation triggers on load, providing the same visual entrance
+- [ ] The accent bar behind "SANCHEZ" can stay as `motion.span` (not LCP)
+
+### 1.2 Make Hero tagline visible on SSR
+
+- [ ] Same pattern for the tagline `<motion.p>` — replace with CSS animation
+- [ ] Keeps the visual entrance effect without blocking LCP
+
+---
+
+## Phase 2: Reduce JS execution time
+
+### 2.1 Lazy-load Hero non-critical components
+
+The Hero imports heavy dependencies that aren't needed for the initial paint:
+
+- `ProximityShape` — floating decorative shapes
+- `CursorBrightGrid` — canvas cursor effect
+- `GridBackground` — SVG grid pattern
+- `MagneticButton` — CTA buttons with hover physics
+- `react-icons/si` — tech stack icons
+
+- [ ] Wrap `ProximityShape` instances in the Hero with a client-only dynamic import
+- [ ] Wrap `CursorBrightGrid` with dynamic import (already lazy in other sections)
+- [ ] Consider lazy-loading `MagneticButton` or simplifying to plain `<a>` for initial render
+
+### 2.2 Defer tech stack pills
+
+- [ ] The tech stack pills (`MagneticPill`) are below the fold on mobile and use `react-icons`
+- [ ] Dynamic import the pills section or gate behind `useInView`
+
+### 2.3 Inline critical LoadingScreen
+
+- [ ] The `LoadingScreen` component imports framer-motion for its animation
+- [ ] If it shows on first visit only (sessionStorage check), consider whether it adds to JS cost on repeat visits where it renders nothing
+
+---
+
+## Phase 3: Reduce render-blocking CSS
+
+### 3.1 Inline critical CSS
+
+- [ ] The render-blocking stylesheet (`db8d7c5499c44d69.css`, 11.4KB) delays FCP by 150ms
+- [ ] Next.js handles CSS optimization automatically — check if `optimizeCss` experimental flag helps
+- [ ] Alternatively, this may be the Tailwind CSS output which must stay render-blocking
+
+---
+
+## Phase 4: Verification
+
+- [ ] Rebuild and run Lighthouse mobile audit
+- [ ] Target: LCP < 2.5s, FCP < 1.8s, Speed Index < 3.4s
+- [ ] Visual verification: Hero entrance animation still works
+- [ ] All tests pass


### PR DESCRIPTION
## Summary

Fix the #1 Lighthouse performance bottleneck: Hero headings were invisible until JS hydrated because framer-motion set `initial={{ opacity: 0 }}` in SSR HTML, causing a **3,030ms LCP render delay**.

Replaced `motion.h1` / `motion.p` with plain `<h1>` / `<p>` elements using CSS `@keyframes` animations. The LCP text ("SANCHEZ") is now visible at `opacity: 1` immediately in the server-rendered HTML.

### Results (localhost, mobile throttling)

| Metric | Before | After |
|---|---|---|
| Performance | 85 | **91** (+6) |
| LCP | 4.3s | **3.5s** |
| LCP render delay | 3,030ms | **132ms** (-96%) |
| TBT | 60ms | **30ms** |

### What changed

- Hero headings ("DIEGO", "SANCHEZ") use CSS `hero-title-1`/`hero-title-2` classes with `hero-slide-up` keyframe (transform only, no opacity hiding)
- Tagline, CTAs, and tech pills use CSS fade+slide animations with delays matching the original framer-motion timing
- Accent bar behind "SANCHEZ" uses CSS `hero-scale-x` keyframe
- All Hero CSS animations respect `prefers-reduced-motion: reduce`
- Removed unused `EASE` import from Hero

## Test plan

- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test` — 388 tests passing
- [x] `pnpm build` — succeeds
- [x] Lighthouse mobile: 91 performance (up from 85)
- [x] Visual verification: Hero entrance animation timing matches original
- [x] Reduced motion: Hero renders without animation