### PR TITLE
perf: lighthouse performance optimization round 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,10 @@ Portfolio for a Senior Frontend Engineer. Next.js 16, React 19, TypeScript, Tail
 - **No transparency on solid UI elements** — cards, buttons, containers use solid colors. Transparency only on decorative/background elements.
 - Components: default export + barrel file (`index.ts`) re-export. Follow existing patterns.
 
+## Spec Files
+
+All spec files live in `/spec` at the project root. Create a new spec file before starting any feature or improvement work.
+
 ## Pre-Implementation Checklist
 
 Before considering any work complete:

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,9 +6,10 @@ import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 
 import { ThemeProvider } from "@/contexts";
 import { LenisProvider } from "@/components/custom/LenisProvider";
+import { MotionProvider } from "@/components/custom/MotionProvider";
 import { LazyCursor } from "@/components/custom/CustomCursor/lazy-cursor";
 import { ToastProvider } from "@/components/common/Toast";
-import { locales } from "@/i18n/config";
+import { locales, defaultLocale } from "@/i18n/config";
 
 import "../globals.css";
 
@@ -45,15 +46,22 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     title: t("title"),
     description: t("description"),
     alternates: {
-      canonical: `https://drsm.vercel.app/${locale}`,
-      languages: Object.fromEntries(locales.map((l) => [l, `https://drsm.vercel.app/${l}`])),
+      canonical:
+        locale === defaultLocale ? "https://drsm.vercel.app" : `https://drsm.vercel.app/${locale}`,
+      languages: Object.fromEntries(
+        locales.map((l) => [
+          l,
+          l === defaultLocale ? "https://drsm.vercel.app" : `https://drsm.vercel.app/${l}`,
+        ])
+      ),
     },
     openGraph: {
       title: t("ogTitle"),
       description: t("ogDescription"),
       locale: locale === "es" ? "es_AR" : "en_US",
       alternateLocale: locale === "es" ? "en_US" : "es_AR",
-      url: `https://drsm.vercel.app/${locale}`,
+      url:
+        locale === defaultLocale ? "https://drsm.vercel.app" : `https://drsm.vercel.app/${locale}`,
       siteName: "Diego Sanchez",
       type: "website",
     },
@@ -83,12 +91,14 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider>
-            <ToastProvider>
-              <LenisProvider>
-                <LazyCursor />
-                {children}
-              </LenisProvider>
-            </ToastProvider>
+            <MotionProvider>
+              <ToastProvider>
+                <LenisProvider>
+                  <LazyCursor />
+                  {children}
+                </LenisProvider>
+              </ToastProvider>
+            </MotionProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/app/globals.css
+++ b/app/globals.css
@@ -189,41 +189,29 @@ body {
   }
 }
 
-@keyframes hero-fade-in {
-  from {
-    opacity: 0;
-  }
-}
-
 .hero-title-1 {
-  animation: hero-slide-up 0.8s var(--ease-out) 0.8s both;
+  animation: hero-slide-up 0.6s var(--ease-out) 0.1s both;
 }
 
 .hero-title-2 {
-  animation: hero-slide-up 0.8s var(--ease-out) 0.9s both;
+  animation: hero-slide-up 0.6s var(--ease-out) 0.2s both;
 }
 
 .hero-accent-bar {
   transform-origin: left;
-  animation: hero-scale-x 0.6s var(--ease-out) 1.2s both;
+  animation: hero-scale-x 0.5s var(--ease-out) 0.4s both;
 }
 
 .hero-tagline {
-  animation:
-    hero-slide-up-sm 0.6s var(--ease-out) 1.6s both,
-    hero-fade-in 0.1s linear 1.6s both;
+  animation: hero-slide-up-sm 0.5s var(--ease-out) 0.3s both;
 }
 
 .hero-cta {
-  animation:
-    hero-slide-up-sm 0.6s var(--ease-out) 1.8s both,
-    hero-fade-in 0.1s linear 1.8s both;
+  animation: hero-slide-up-sm 0.5s var(--ease-out) 0.4s both;
 }
 
 .hero-pills {
-  animation:
-    hero-slide-up-sm 0.6s var(--ease-out) 0.5s both,
-    hero-fade-in 0.1s linear 0.5s both;
+  animation: hero-slide-up-sm 0.5s var(--ease-out) 0.15s both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/common/Avatar/avatar.test.tsx
+++ b/components/common/Avatar/avatar.test.tsx
@@ -1,30 +1,34 @@
 import React, { act } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
-      const motionKeys = [
-        "initial",
-        "animate",
-        "exit",
-        "transition",
-        "whileHover",
-        "whileTap",
-        "whileInView",
-        "viewport",
-        "variants",
-      ];
-      const filtered: Record<string, unknown> = {};
-      for (const key in props) {
-        if (!motionKeys.includes(key)) {
-          filtered[key] = props[key];
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+        const motionKeys = [
+          "initial",
+          "animate",
+          "exit",
+          "transition",
+          "whileHover",
+          "whileTap",
+          "whileInView",
+          "viewport",
+          "variants",
+        ];
+        const filtered: Record<string, unknown> = {};
+        for (const key in props) {
+          if (!motionKeys.includes(key)) {
+            filtered[key] = props[key];
+          }
         }
-      }
-      return <div {...filtered}>{children}</div>;
+        return <div {...filtered}>{children}</div>;
+      },
     },
-  },
-}));
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/components/common/Avatar/avatar.tsx
+++ b/components/common/Avatar/avatar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import NextImage from "next/image";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "@/utils";
 
 interface AvatarProps {
@@ -55,7 +55,7 @@ function Avatar({
   const showFallback = !src || hasError;
 
   return (
-    <motion.div
+    <m.div
       className={cn(
         "bg-elevated relative flex shrink-0 items-center justify-center overflow-hidden",
         sizeClasses[size],
@@ -87,7 +87,7 @@ function Avatar({
           />
         </>
       )}
-    </motion.div>
+    </m.div>
   );
 }
 

--- a/components/common/Badge/badge.test.tsx
+++ b/components/common/Badge/badge.test.tsx
@@ -1,30 +1,34 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
-      const motionKeys = [
-        "initial",
-        "animate",
-        "exit",
-        "transition",
-        "whileHover",
-        "whileTap",
-        "whileInView",
-        "viewport",
-        "variants",
-      ];
-      const filtered: Record<string, unknown> = {};
-      for (const key in props) {
-        if (!motionKeys.includes(key)) {
-          filtered[key] = props[key];
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+        const motionKeys = [
+          "initial",
+          "animate",
+          "exit",
+          "transition",
+          "whileHover",
+          "whileTap",
+          "whileInView",
+          "viewport",
+          "variants",
+        ];
+        const filtered: Record<string, unknown> = {};
+        for (const key in props) {
+          if (!motionKeys.includes(key)) {
+            filtered[key] = props[key];
+          }
         }
-      }
-      return <span {...filtered}>{children}</span>;
+        return <span {...filtered}>{children}</span>;
+      },
     },
-  },
-}));
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { Badge } from "./badge";
 

--- a/components/common/Badge/badge.tsx
+++ b/components/common/Badge/badge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "@/utils";
 
 interface BadgeProps {
@@ -27,7 +27,7 @@ const sizeClasses = {
 
 const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
   ({ children, variant = "default", size = "md", className, animated = false }, ref) => {
-    const Component = animated ? motion.span : "span";
+    const Component = animated ? m.span : "span";
 
     return (
       <Component

--- a/components/common/ContactForm/contact-form.test.tsx
+++ b/components/common/ContactForm/contact-form.test.tsx
@@ -23,27 +23,33 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <label {...filterMotionProps(props)}>{children}</label>
-    ),
-    input: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) => (
-      <input ref={ref} {...filterMotionProps(props)} />
-    )),
-    textarea: React.forwardRef(
-      (props: Record<string, unknown>, ref: React.Ref<HTMLTextAreaElement>) => (
-        <textarea ref={ref} {...filterMotionProps(props)} />
-      )
-    ),
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...filterMotionProps(props)}>{children}</button>
-    ),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-  },
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <label {...filterMotionProps(props)}>{children}</label>
+      ),
+      input: React.forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) => (
+          <input ref={ref} {...filterMotionProps(props)} />
+        )
+      ),
+      textarea: React.forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLTextAreaElement>) => (
+          <textarea ref={ref} {...filterMotionProps(props)} />
+        )
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...filterMotionProps(props)}>{children}</button>
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+    },
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 const mockAddToast = jest.fn();
 jest.mock("../Toast", () => ({

--- a/components/common/ContactForm/contact-form.tsx
+++ b/components/common/ContactForm/contact-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { Send, Loader2 } from "lucide-react";
 import { cn } from "@/utils";
 import { Input } from "../Input";
@@ -141,7 +141,7 @@ function ContactForm({ onSubmit, className }: ContactFormProps) {
         error={errors.message}
       />
 
-      <motion.button
+      <m.button
         type="submit"
         disabled={isSubmitting}
         className={cn(
@@ -162,7 +162,7 @@ function ContactForm({ onSubmit, className }: ContactFormProps) {
             Send Message
           </>
         )}
-      </motion.button>
+      </m.button>
     </form>
   );
 }

--- a/components/common/ExperienceCard/experience-card.test.tsx
+++ b/components/common/ExperienceCard/experience-card.test.tsx
@@ -24,17 +24,21 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <article {...filterMotionProps(props)}>{children}</article>
-    ),
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <article {...filterMotionProps(props)}>{children}</article>
+      ),
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/components/common/ExperienceCard/experience-card.tsx
+++ b/components/common/ExperienceCard/experience-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import NextImage from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { cn } from "@/utils";
 
 interface ExperienceCardProps {
@@ -28,13 +28,13 @@ function ExperienceCard({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.article
+    <m.article
       className={cn("relative flex gap-6", className)}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       <div className="relative flex flex-col items-center">
-        <motion.div
+        <m.div
           className="border-accent bg-background relative z-10 flex h-4 w-4 items-center justify-center border-2"
           animate={{
             scale: isHovered ? 1.25 : 1,
@@ -45,7 +45,7 @@ function ExperienceCard({
         <div className="bg-border absolute top-4 h-full w-px" />
       </div>
 
-      <motion.div
+      <m.div
         className="border-border bg-surface flex-1 border p-6 pb-8"
         animate={{
           borderColor: isHovered ? "rgba(139, 92, 246, 0.5)" : "var(--color-border)",
@@ -81,8 +81,8 @@ function ExperienceCard({
             ))}
           </div>
         )}
-      </motion.div>
-    </motion.article>
+      </m.div>
+    </m.article>
   );
 }
 

--- a/components/common/Footer/footer.test.tsx
+++ b/components/common/Footer/footer.test.tsx
@@ -22,21 +22,25 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    nav: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <nav {...filterMotionProps(props)}>{children}</nav>
-    ),
-  },
-  useReducedMotion: () => false,
-  useInView: () => true,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      nav: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <nav {...filterMotionProps(props)}>{children}</nav>
+      ),
+    },
+    useReducedMotion: () => false,
+    useInView: () => true,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("@/i18n/routing", () => ({
   Link: ({

--- a/components/common/Footer/footer.tsx
+++ b/components/common/Footer/footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import { motion, useReducedMotion, useInView } from "framer-motion";
+import { m, useReducedMotion, useInView } from "framer-motion";
 import { ArrowUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { ACCENT_HEX, EASE } from "@/utils";
@@ -32,7 +32,7 @@ function Footer() {
       aria-label="Site footer"
     >
       {/* Ghost monogram — mobile/tablet: full-width, half-cropped at bottom */}
-      <motion.span
+      <m.span
         className="pointer-events-none absolute bottom-[-20%] left-0 w-screen text-[42vw] leading-none font-black whitespace-nowrap text-white/[0.06] select-none lg:hidden"
         style={{ fontFamily: "var(--font-display)" }}
         initial={{ opacity: 0 }}
@@ -41,9 +41,9 @@ function Footer() {
         aria-hidden="true"
       >
         DRSM
-      </motion.span>
+      </m.span>
       {/* Ghost monogram — desktop: positioned right */}
-      <motion.span
+      <m.span
         className="pointer-events-none absolute right-[-5%] bottom-[-20%] hidden text-[28vw] leading-none font-black text-white/[0.06] select-none lg:block"
         style={{ fontFamily: "var(--font-display)" }}
         initial={{ opacity: 0, x: shouldReduceMotion ? 0 : 50 }}
@@ -52,13 +52,13 @@ function Footer() {
         aria-hidden="true"
       >
         DRSM
-      </motion.span>
+      </m.span>
 
       <div className="relative mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 sm:py-14">
         {/* Main content row */}
         <div className="flex flex-col gap-8 md:flex-row md:items-end md:justify-between">
           {/* Branding */}
-          <motion.div
+          <m.div
             initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 15 }}
             animate={isInView ? { opacity: 1, y: 0 } : {}}
             transition={{ duration: 0.6, ease: EASE }}
@@ -70,10 +70,10 @@ function Footer() {
               DIEGO SANCHEZ
             </h2>
             <p className="max-w-sm text-sm text-white/60">{t("description")}</p>
-          </motion.div>
+          </m.div>
 
           {/* Navigation */}
-          <motion.nav
+          <m.nav
             className="flex flex-wrap gap-4 sm:gap-5"
             aria-label="Footer navigation"
             initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 15 }}
@@ -101,11 +101,11 @@ function Footer() {
                 {tNav(key)}
               </a>
             ))}
-          </motion.nav>
+          </m.nav>
         </div>
 
         {/* Bottom bar */}
-        <motion.div
+        <m.div
           className="mt-8 flex items-center justify-between border-t border-white/10 pt-6 sm:mt-10"
           initial={{ opacity: 0 }}
           animate={isInView ? { opacity: 1 } : {}}
@@ -120,18 +120,18 @@ function Footer() {
           >
             <ArrowUp className="h-3 w-3" aria-hidden="true" /> {t("scrollToTop")}
           </button>
-        </motion.div>
+        </m.div>
       </div>
 
       {/* Decorative shapes */}
-      <motion.div
+      <m.div
         className="absolute top-[20%] left-[8%] h-3 w-3 rotate-45 sm:h-4 sm:w-4"
         style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
         animate={shouldReduceMotion ? {} : { y: [0, -6, 0] }}
         transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }}
         aria-hidden="true"
       />
-      <motion.div
+      <m.div
         className="absolute bottom-[30%] left-[25%] h-2 w-2 rounded-full sm:h-3 sm:w-3"
         style={{ backgroundColor: "rgba(255,255,255,0.06)" }}
         animate={shouldReduceMotion ? {} : { y: [0, 5, 0] }}

--- a/components/common/Image/image.test.tsx
+++ b/components/common/Image/image.test.tsx
@@ -1,30 +1,34 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
-      const motionKeys = [
-        "initial",
-        "animate",
-        "exit",
-        "transition",
-        "whileHover",
-        "whileTap",
-        "whileInView",
-        "viewport",
-        "variants",
-      ];
-      const filtered: Record<string, unknown> = {};
-      for (const key in props) {
-        if (!motionKeys.includes(key)) {
-          filtered[key] = props[key];
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+        const motionKeys = [
+          "initial",
+          "animate",
+          "exit",
+          "transition",
+          "whileHover",
+          "whileTap",
+          "whileInView",
+          "viewport",
+          "variants",
+        ];
+        const filtered: Record<string, unknown> = {};
+        for (const key in props) {
+          if (!motionKeys.includes(key)) {
+            filtered[key] = props[key];
+          }
         }
-      }
-      return <div {...filtered}>{children}</div>;
+        return <div {...filtered}>{children}</div>;
+      },
     },
-  },
-}));
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/components/common/Image/image.tsx
+++ b/components/common/Image/image.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import NextImage from "next/image";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "@/utils";
 
 interface ImageProps {
@@ -39,7 +39,7 @@ function Image({
     >
       {!isLoaded && <div className="bg-elevated absolute inset-0 animate-pulse" />}
 
-      <motion.div
+      <m.div
         className="h-full w-full"
         animate={{
           scale: hover === "zoom" && isHovered ? 1.05 : 1,
@@ -74,7 +74,7 @@ function Image({
             onLoad={() => setIsLoaded(true)}
           />
         )}
-      </motion.div>
+      </m.div>
     </div>
   );
 }

--- a/components/common/Input/input.test.tsx
+++ b/components/common/Input/input.test.tsx
@@ -23,19 +23,25 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <label {...filterMotionProps(props)}>{children}</label>
-    ),
-    input: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) => (
-      <input ref={ref} {...filterMotionProps(props)} />
-    )),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-  },
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <label {...filterMotionProps(props)}>{children}</label>
+      ),
+      input: React.forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLInputElement>) => (
+          <input ref={ref} {...filterMotionProps(props)} />
+        )
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+    },
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { Input } from "./input";
 

--- a/components/common/Input/input.tsx
+++ b/components/common/Input/input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef, useState } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "@/utils";
 
 interface InputProps {
@@ -51,7 +51,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     return (
       <div className={cn("relative", className)}>
-        <motion.label
+        <m.label
           htmlFor={name}
           className={cn(
             "text-muted pointer-events-none absolute left-4 origin-left transition-colors",
@@ -70,9 +70,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         >
           {label}
           {required && <span className="text-accent ml-1">*</span>}
-        </motion.label>
+        </m.label>
 
-        <motion.input
+        <m.input
           ref={ref}
           id={name}
           name={name}
@@ -101,7 +101,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         />
 
         {error && (
-          <motion.p
+          <m.p
             className="mt-1.5 text-sm text-red-500"
             initial={{ opacity: 0, y: -4 }}
             animate={{ opacity: 1, y: 0 }}
@@ -109,7 +109,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             role="alert"
           >
             {error}
-          </motion.p>
+          </m.p>
         )}
       </div>
     );

--- a/components/common/LoadingScreen/loading-screen.test.tsx
+++ b/components/common/LoadingScreen/loading-screen.test.tsx
@@ -3,55 +3,59 @@ import { LoadingScreen } from "./loading-screen";
 
 const mockSessionStorage: Record<string, string> = {};
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({
-      children,
-      className,
-      role,
-      "aria-label": ariaLabel,
-      "aria-hidden": ariaHidden,
-      style,
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-      role?: string;
-      "aria-label"?: string;
-      "aria-hidden"?: string;
-      style?: React.CSSProperties;
-    }) => (
-      <div
-        className={className}
-        role={role}
-        aria-label={ariaLabel}
-        aria-hidden={ariaHidden}
-        style={style}
-      >
-        {children}
-      </div>
-    ),
-    span: ({
-      children,
-      className,
-      style,
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-      style?: React.CSSProperties;
-    }) => (
-      <span className={className} style={style}>
-        {children}
-      </span>
-    ),
-    p: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
-      <p className={className}>{children}</p>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn(), get: () => 0 }),
-  useSpring: () => ({ set: jest.fn() }),
-  useReducedMotion: () => false,
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({
+        children,
+        className,
+        role,
+        "aria-label": ariaLabel,
+        "aria-hidden": ariaHidden,
+        style,
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        role?: string;
+        "aria-label"?: string;
+        "aria-hidden"?: string;
+        style?: React.CSSProperties;
+      }) => (
+        <div
+          className={className}
+          role={role}
+          aria-label={ariaLabel}
+          aria-hidden={ariaHidden}
+          style={style}
+        >
+          {children}
+        </div>
+      ),
+      span: ({
+        children,
+        className,
+        style,
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        style?: React.CSSProperties;
+      }) => (
+        <span className={className} style={style}>
+          {children}
+        </span>
+      ),
+      p: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <p className={className}>{children}</p>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn(), get: () => 0 }),
+    useSpring: () => ({ set: jest.fn() }),
+    useReducedMotion: () => false,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("LoadingScreen", () => {
   beforeEach(() => {

--- a/components/common/LoadingScreen/loading-screen.tsx
+++ b/components/common/LoadingScreen/loading-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { m, AnimatePresence, useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 
 interface LoadingScreenProps {
@@ -60,7 +60,7 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
   return (
     <AnimatePresence>
       {isLoading && (
-        <motion.div
+        <m.div
           className="bg-background fixed inset-0 z-[10000] flex h-screen w-screen items-center justify-center"
           role="status"
           aria-label="Loading"
@@ -80,7 +80,7 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
               { x: "65%", y: "85%", size: 36, shape: "square", delay: 0.1 },
               { x: "95%", y: "88%", size: 28, shape: "square", delay: 0.7 },
             ].map((item, i) => (
-              <motion.div
+              <m.div
                 key={i}
                 className={`absolute ${item.shape === "circle" ? "rounded-full" : "rounded-sm"} bg-accent`}
                 style={{
@@ -123,7 +123,7 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
           </div>
 
           {/* Center glow */}
-          <motion.div
+          <m.div
             className="pointer-events-none absolute h-[400px] w-[400px] rounded-full"
             aria-hidden="true"
             style={{
@@ -146,7 +146,7 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
               {letters.map((letter, index) => (
                 <div key={letter} className="relative">
                   {/* Trace outline - same size as solid letter */}
-                  <motion.span
+                  <m.span
                     className="absolute inset-0 text-6xl font-black tracking-tight md:text-8xl"
                     style={{
                       fontFamily: "var(--font-display)",
@@ -164,10 +164,10 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
                     }}
                   >
                     {letter}
-                  </motion.span>
+                  </m.span>
 
                   {/* Solid letter that fades in after trace */}
-                  <motion.span
+                  <m.span
                     className="text-foreground relative text-6xl font-black tracking-tight md:text-8xl"
                     style={{ fontFamily: "var(--font-display)" }}
                     initial={{ opacity: 0 }}
@@ -181,13 +181,13 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
                     }}
                   >
                     {letter}
-                  </motion.span>
+                  </m.span>
                 </div>
               ))}
             </div>
 
             {/* Tagline teaser */}
-            <motion.p
+            <m.p
               className="text-muted/80 text-sm tracking-wide md:text-base"
               initial={{ opacity: 0, y: 10 }}
               animate={{
@@ -201,19 +201,19 @@ export function LoadingScreen({ onComplete, minimumLoadTime = 2200 }: LoadingScr
               }}
             >
               {t("tagline")}
-            </motion.p>
+            </m.p>
           </div>
 
           {/* Progress bar at bottom */}
           <div className="bg-accent/10 absolute right-0 bottom-0 left-0 h-2">
-            <motion.div
+            <m.div
               className="bg-accent h-full"
               initial={{ width: "0%" }}
               animate={{ width: `${progress}%` }}
               transition={{ duration: 0.1, ease: "linear" }}
             />
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/components/common/MobileMenu/mobile-menu.test.tsx
+++ b/components/common/MobileMenu/mobile-menu.test.tsx
@@ -22,24 +22,28 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...filterMotionProps(props)}>{children}</button>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-  },
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...filterMotionProps(props)}>{children}</button>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/link", () => ({
   __esModule: true,

--- a/components/common/MobileMenu/mobile-menu.tsx
+++ b/components/common/MobileMenu/mobile-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { m, AnimatePresence, useReducedMotion } from "framer-motion";
 import Link from "next/link";
 import { X } from "lucide-react";
 import { cn } from "@/utils";
@@ -40,7 +40,7 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
   return (
     <AnimatePresence>
       {isOpen && (
-        <motion.div
+        <m.div
           className={cn("bg-background fixed inset-0 z-50 flex flex-col", className)}
           initial={{
             clipPath: shouldReduceMotion
@@ -58,7 +58,7 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
           aria-modal="true"
           aria-label="Navigation menu"
         >
-          <motion.div
+          <m.div
             className="absolute inset-0"
             style={{
               background:
@@ -72,7 +72,7 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
           />
 
           <div className="flex items-center justify-end p-6">
-            <motion.button
+            <m.button
               onClick={onClose}
               className="magnetic text-foreground hover:bg-surface focus-visible:ring-accent focus-visible:ring-offset-background p-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
               initial={{
@@ -88,7 +88,7 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
               aria-label="Close menu"
             >
               <X className="h-6 w-6" />
-            </motion.button>
+            </m.button>
           </div>
 
           <nav
@@ -96,7 +96,7 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
             aria-label="Main navigation"
           >
             {links.map((link, index) => (
-              <motion.div
+              <m.div
                 key={link.href}
                 initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 30 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -114,18 +114,18 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
                   style={{ fontFamily: "var(--font-display)" }}
                 >
                   {link.label}
-                  <motion.span
+                  <m.span
                     className="bg-accent absolute -bottom-2 left-0 h-0.5"
                     initial={{ width: 0 }}
                     whileHover={{ width: "100%" }}
                     transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
                   />
                 </Link>
-              </motion.div>
+              </m.div>
             ))}
           </nav>
 
-          <motion.div
+          <m.div
             className="p-6 text-center"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -133,8 +133,8 @@ function MobileMenu({ isOpen, onClose, links, className }: MobileMenuProps) {
             transition={{ delay: 0.3 }}
           >
             <p className="text-muted text-sm">Let&apos;s build something amazing together.</p>
-          </motion.div>
-        </motion.div>
+          </m.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/components/common/Navbar/navbar.test.tsx
+++ b/components/common/Navbar/navbar.test.tsx
@@ -51,91 +51,95 @@ jest.mock("@/i18n/routing", () => ({
   usePathname: () => "/",
 }));
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({
-      children,
-      className,
-      onClick,
-      role,
-      "aria-modal": ariaModal,
-      "aria-label": ariaLabel,
-    }: {
-      children: React.ReactNode;
-      className?: string;
-      onClick?: () => void;
-      role?: string;
-      "aria-modal"?: boolean;
-      "aria-label"?: string;
-    }) => (
-      <div
-        className={className}
-        onClick={onClick}
-        role={role}
-        aria-modal={ariaModal}
-        aria-label={ariaLabel}
-      >
-        {children}
-      </div>
-    ),
-    span: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-      <span className={className}>{children}</span>
-    ),
-    button: ({
-      children,
-      onClick,
-      className,
-      "aria-label": ariaLabel,
-      "aria-expanded": ariaExpanded,
-      "aria-controls": ariaControls,
-    }: {
-      children: React.ReactNode;
-      onClick?: () => void;
-      className?: string;
-      "aria-label"?: string;
-      "aria-expanded"?: boolean;
-      "aria-controls"?: string;
-    }) => (
-      <button
-        onClick={onClick}
-        className={className}
-        aria-label={ariaLabel}
-        aria-expanded={ariaExpanded}
-        aria-controls={ariaControls}
-      >
-        {children}
-      </button>
-    ),
-    a: ({
-      children,
-      href,
-      className,
-      onClick,
-    }: {
-      children: React.ReactNode;
-      href: string;
-      className?: string;
-      onClick?: () => void;
-    }) => (
-      <a href={href} className={className} onClick={onClick}>
-        {children}
-      </a>
-    ),
-    li: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-      <li className={className}>{children}</li>
-    ),
-    path: ({ fill, d }: { fill: string; d: string }) => <path fill={fill} d={d} />,
-    svg: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
-      <svg className={className}>{children}</svg>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn(), get: () => 0, on: () => () => {} }),
-  useSpring: () => ({ set: jest.fn(), get: () => 0 }),
-  useTransform: () => ({ set: jest.fn(), get: () => 0 }),
-  useReducedMotion: () => false,
-  useAnimationFrame: () => {},
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({
+        children,
+        className,
+        onClick,
+        role,
+        "aria-modal": ariaModal,
+        "aria-label": ariaLabel,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+        onClick?: () => void;
+        role?: string;
+        "aria-modal"?: boolean;
+        "aria-label"?: string;
+      }) => (
+        <div
+          className={className}
+          onClick={onClick}
+          role={role}
+          aria-modal={ariaModal}
+          aria-label={ariaLabel}
+        >
+          {children}
+        </div>
+      ),
+      span: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+        <span className={className}>{children}</span>
+      ),
+      button: ({
+        children,
+        onClick,
+        className,
+        "aria-label": ariaLabel,
+        "aria-expanded": ariaExpanded,
+        "aria-controls": ariaControls,
+      }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+        className?: string;
+        "aria-label"?: string;
+        "aria-expanded"?: boolean;
+        "aria-controls"?: string;
+      }) => (
+        <button
+          onClick={onClick}
+          className={className}
+          aria-label={ariaLabel}
+          aria-expanded={ariaExpanded}
+          aria-controls={ariaControls}
+        >
+          {children}
+        </button>
+      ),
+      a: ({
+        children,
+        href,
+        className,
+        onClick,
+      }: {
+        children: React.ReactNode;
+        href: string;
+        className?: string;
+        onClick?: () => void;
+      }) => (
+        <a href={href} className={className} onClick={onClick}>
+          {children}
+        </a>
+      ),
+      li: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+        <li className={className}>{children}</li>
+      ),
+      path: ({ fill, d }: { fill: string; d: string }) => <path fill={fill} d={d} />,
+      svg: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <svg className={className}>{children}</svg>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn(), get: () => 0, on: () => () => {} }),
+    useSpring: () => ({ set: jest.fn(), get: () => 0 }),
+    useTransform: () => ({ set: jest.fn(), get: () => 0 }),
+    useReducedMotion: () => false,
+    useAnimationFrame: () => {},
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("lucide-react", () => ({
   Globe: () => <span data-testid="globe-icon">Globe</span>,

--- a/components/common/Navbar/navbar.tsx
+++ b/components/common/Navbar/navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import {
-  motion,
+  m,
   useMotionValue,
   useSpring,
   useTransform,
@@ -73,7 +73,7 @@ function MagneticLetter({
   const magneticY = useTransform(springY, (val) => (enableMotion ? val * factor.y : 0));
 
   return (
-    <motion.span
+    <m.span
       className="inline-block"
       animate={{
         x: enableMotion && isHovered ? position.x : 0,
@@ -81,10 +81,10 @@ function MagneticLetter({
       }}
       transition={{ duration: enableMotion ? 0.35 : 0, ease: EASE }}
     >
-      <motion.span className="inline-block" style={{ x: magneticX, y: magneticY }}>
+      <m.span className="inline-block" style={{ x: magneticX, y: magneticY }}>
         {letter}
-      </motion.span>
-    </motion.span>
+      </m.span>
+    </m.span>
   );
 }
 
@@ -117,7 +117,7 @@ function MagneticLogo() {
   };
 
   return (
-    <motion.div
+    <m.div
       ref={containerRef}
       className="relative -ml-2 cursor-pointer px-2 py-4 select-none"
       onMouseEnter={() => setIsHovered(true)}
@@ -125,7 +125,7 @@ function MagneticLogo() {
       onMouseLeave={handleMouseLeave}
       aria-label={t("home")}
     >
-      <motion.div
+      <m.div
         className="text-foreground flex items-center text-2xl font-black tracking-tight"
         style={{ fontFamily: "var(--font-display)" }}
         aria-hidden="true"
@@ -141,8 +141,8 @@ function MagneticLogo() {
             enableMotion={enableMotion}
           />
         ))}
-      </motion.div>
-    </motion.div>
+      </m.div>
+    </m.div>
   );
 }
 
@@ -193,7 +193,7 @@ function LanguageToggle({
   const menuIconColor = isMenuOpen ? (theme === "dark" ? "#ffffff" : "#000000") : undefined;
 
   return (
-    <motion.button
+    <m.button
       ref={buttonRef}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
@@ -208,7 +208,7 @@ function LanguageToggle({
       whileTap={enableMotion ? { scale: 0.95 } : {}}
       aria-label={t("toggleLanguage")}
     >
-      <motion.div
+      <m.div
         style={{
           x: enableMotion ? springX : 0,
           y: enableMotion ? springY : 0,
@@ -216,8 +216,8 @@ function LanguageToggle({
         }}
       >
         <Globe className="h-5 w-5" />
-      </motion.div>
-    </motion.button>
+      </m.div>
+    </m.button>
   );
 }
 
@@ -230,7 +230,7 @@ function Hamburger({ isOpen, onClick }: { isOpen: boolean; onClick: () => void }
   const t = useTranslations("nav");
 
   return (
-    <motion.button
+    <m.button
       className="focus-visible:ring-accent focus-visible:ring-offset-background relative -mr-[10px] flex h-11 w-11 flex-col items-center justify-center gap-1.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       onClick={onClick}
       whileTap={shouldReduceMotion ? {} : { scale: 0.95 }}
@@ -238,25 +238,25 @@ function Hamburger({ isOpen, onClick }: { isOpen: boolean; onClick: () => void }
       aria-expanded={isOpen}
       aria-controls="main-menu"
     >
-      <motion.span
+      <m.span
         className="bg-foreground block h-0.5 w-6"
         animate={{ rotate: isOpen ? 45 : 0, y: isOpen ? 8 : 0 }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.3, ease: EASE }}
         aria-hidden="true"
       />
-      <motion.span
+      <m.span
         className="bg-foreground block h-0.5 w-6"
         animate={{ opacity: isOpen ? 0 : 1, scaleX: isOpen ? 0 : 1 }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
         aria-hidden="true"
       />
-      <motion.span
+      <m.span
         className="bg-foreground block h-0.5 w-6"
         animate={{ rotate: isOpen ? -45 : 0, y: isOpen ? -8 : 0 }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.3, ease: EASE }}
         aria-hidden="true"
       />
-    </motion.button>
+    </m.button>
   );
 }
 
@@ -600,7 +600,7 @@ function RailShape({
 
   if (config.type === "triangle") {
     return (
-      <motion.div
+      <m.div
         className="pointer-events-auto absolute cursor-grab active:cursor-grabbing"
         style={{ width: s, height: s, ...baseStyle }}
         {...baseAnim}
@@ -609,12 +609,12 @@ function RailShape({
         <svg width={s} height={s} viewBox={`0 0 ${s} ${s}`} aria-hidden="true">
           <polygon points={`${s / 2},0 ${s},${s} 0,${s}`} fill={c} />
         </svg>
-      </motion.div>
+      </m.div>
     );
   }
 
   return (
-    <motion.div
+    <m.div
       className={`pointer-events-auto absolute cursor-grab active:cursor-grabbing ${config.type === "circle" ? "rounded-full" : ""}`}
       style={{ width: s, height: s, backgroundColor: c, ...baseStyle }}
       {...baseAnim}
@@ -872,7 +872,7 @@ function MagneticNavLink({
       onMouseEnter={() => onHover(index)}
       onMouseLeave={handleMouseLeave}
     >
-      <motion.a
+      <m.a
         href={`#${navKey}`}
         className="group relative block cursor-pointer focus-visible:outline-none"
         style={{ x: enableMotion ? springX : 0, y: enableMotion ? springY : 0 }}
@@ -884,7 +884,7 @@ function MagneticNavLink({
         onBlur={() => onFocus(null)}
       >
         <span className="relative inline-block">
-          <motion.span
+          <m.span
             className="relative z-10 flex items-center justify-center text-5xl font-black md:text-6xl"
             style={{
               fontFamily: "var(--font-display)",
@@ -896,8 +896,8 @@ function MagneticNavLink({
             transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
           >
             {t(navKey)}
-          </motion.span>
-          <motion.span
+          </m.span>
+          <m.span
             className="absolute -inset-x-5 -inset-y-2 -z-0"
             style={{ backgroundColor: highlightColor, originX: 0 }}
             initial={{ scaleX: 0 }}
@@ -906,7 +906,7 @@ function MagneticNavLink({
             aria-hidden="true"
           />
         </span>
-      </motion.a>
+      </m.a>
     </div>
   );
 }
@@ -934,7 +934,7 @@ function CurtainContent({ onClose }: { onClose: (navKey: string) => void }) {
       <nav className="relative z-10" aria-label="Main navigation">
         <ul className="flex flex-col items-center justify-center gap-8 pt-20" role="list">
           {NAV_KEYS.map((key, i) => (
-            <motion.li
+            <m.li
               key={key}
               initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 30 }}
               animate={{ opacity: 1, y: 0 }}
@@ -954,7 +954,7 @@ function CurtainContent({ onClose }: { onClose: (navKey: string) => void }) {
                 onFocus={setFocusedIndex}
                 onClose={onClose}
               />
-            </motion.li>
+            </m.li>
           ))}
         </ul>
       </nav>
@@ -1050,7 +1050,7 @@ function Navbar({ className }: NavbarProps) {
         style={{ paddingRight: scrollbarWidth > 0 ? scrollbarWidth : undefined }}
         role="banner"
       >
-        <motion.div
+        <m.div
           className="bg-border absolute right-0 bottom-0 left-0 h-px"
           initial={{ scaleX: 0 }}
           animate={{ scaleX: scrolled && !isOpen ? 1 : 0 }}
@@ -1076,7 +1076,7 @@ function Navbar({ className }: NavbarProps) {
 
       <AnimatePresence>
         {isOpen && (
-          <motion.div
+          <m.div
             id="main-menu"
             className="bg-accent fixed inset-0 z-40"
             initial={{ clipPath: "inset(0 0 100% 0)" }}
@@ -1088,7 +1088,7 @@ function Navbar({ className }: NavbarProps) {
             aria-label="Navigation menu"
           >
             <CurtainContent onClose={closeMenu} />
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
     </>

--- a/components/common/ProjectCard/project-card.test.tsx
+++ b/components/common/ProjectCard/project-card.test.tsx
@@ -24,17 +24,21 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <article {...filterMotionProps(props)}>{children}</article>
-    ),
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <article {...filterMotionProps(props)}>{children}</article>
+      ),
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/components/common/ProjectCard/project-card.tsx
+++ b/components/common/ProjectCard/project-card.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import NextImage from "next/image";
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/utils";
 
@@ -38,7 +38,7 @@ function ProjectCard({
         className
       )}
     >
-      <motion.article
+      <m.article
         className={cn(
           "border-border bg-surface relative overflow-hidden border",
           featured && "md:col-span-2"
@@ -56,7 +56,7 @@ function ProjectCard({
       >
         <div className="relative aspect-video overflow-hidden">
           {!imageLoaded && <div className="bg-elevated absolute inset-0 animate-pulse" />}
-          <motion.div
+          <m.div
             className="h-full w-full"
             animate={{ scale: isHovered ? 1.05 : 1 }}
             transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
@@ -68,8 +68,8 @@ function ProjectCard({
               className="object-cover"
               onLoad={() => setImageLoaded(true)}
             />
-          </motion.div>
-          <motion.div
+          </m.div>
+          <m.div
             className="from-surface absolute inset-0 bg-gradient-to-t via-transparent to-transparent"
             animate={{ opacity: isHovered ? 0.8 : 0.6 }}
             transition={{ duration: 0.3 }}
@@ -81,7 +81,7 @@ function ProjectCard({
             <h3 className="text-xl font-semibold" style={{ fontFamily: "var(--font-display)" }}>
               {title}
             </h3>
-            <motion.div
+            <m.div
               animate={{
                 x: isHovered ? 0 : -4,
                 y: isHovered ? 0 : 4,
@@ -90,7 +90,7 @@ function ProjectCard({
               transition={{ duration: 0.2 }}
             >
               <ArrowUpRight className="text-accent h-5 w-5" />
-            </motion.div>
+            </m.div>
           </div>
 
           <p className="text-muted mb-4 line-clamp-2 text-sm">{description}</p>
@@ -105,7 +105,7 @@ function ProjectCard({
         </div>
 
         {isHovered && (
-          <motion.div
+          <m.div
             className="pointer-events-none absolute inset-0"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -117,7 +117,7 @@ function ProjectCard({
             aria-hidden="true"
           />
         )}
-      </motion.article>
+      </m.article>
     </Link>
   );
 }

--- a/components/common/ScrollToTop/scroll-to-top.test.tsx
+++ b/components/common/ScrollToTop/scroll-to-top.test.tsx
@@ -22,18 +22,22 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...filterMotionProps(props)}>{children}</button>
-    ),
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...filterMotionProps(props)}>{children}</button>
+      ),
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("lucide-react", () => ({
   ArrowUp: ({ className }: { className?: string }) => (

--- a/components/common/ScrollToTop/scroll-to-top.tsx
+++ b/components/common/ScrollToTop/scroll-to-top.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { m, AnimatePresence, useReducedMotion } from "framer-motion";
 import { ArrowUp } from "lucide-react";
 import { cn } from "@/utils";
 
@@ -32,7 +32,7 @@ function ScrollToTop({ threshold = 400, className }: ScrollToTopProps) {
   return (
     <AnimatePresence>
       {isVisible && (
-        <motion.button
+        <m.button
           onClick={scrollToTop}
           className={cn(
             "magnetic border-border bg-surface hover:border-accent hover:bg-elevated focus-visible:ring-accent focus-visible:ring-offset-background fixed right-6 bottom-6 z-40 flex h-12 w-12 items-center justify-center border shadow-lg transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
@@ -48,7 +48,7 @@ function ScrollToTop({ threshold = 400, className }: ScrollToTopProps) {
           whileTap={{ scale: 0.95 }}
           aria-label="Scroll to top"
         >
-          <motion.div
+          <m.div
             animate={shouldReduceMotion ? {} : { y: [0, -2, 0] }}
             transition={
               shouldReduceMotion
@@ -62,8 +62,8 @@ function ScrollToTop({ threshold = 400, className }: ScrollToTopProps) {
             }
           >
             <ArrowUp className="text-accent h-5 w-5" />
-          </motion.div>
-        </motion.button>
+          </m.div>
+        </m.button>
       )}
     </AnimatePresence>
   );

--- a/components/common/SkillCard/skill-card.test.tsx
+++ b/components/common/SkillCard/skill-card.test.tsx
@@ -24,14 +24,18 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { SkillCard } from "./skill-card";
 

--- a/components/common/SkillCard/skill-card.tsx
+++ b/components/common/SkillCard/skill-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { cn } from "@/utils";
 
 interface SkillCardProps {
@@ -31,7 +31,7 @@ function SkillCard({ name, icon, level, category, className }: SkillCardProps) {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.div
+    <m.div
       className={cn(
         "border-border bg-surface flex flex-col items-center gap-3 border p-6",
         className
@@ -46,13 +46,13 @@ function SkillCard({ name, icon, level, category, className }: SkillCardProps) {
       }}
       transition={{ duration: shouldReduceMotion ? 0 : 0.3, ease: [0.22, 1, 0.36, 1] }}
     >
-      <motion.div
+      <m.div
         className="text-accent flex h-12 w-12 items-center justify-center"
         animate={{ scale: isHovered && !shouldReduceMotion ? 1.1 : 1 }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
       >
         {icon}
-      </motion.div>
+      </m.div>
 
       <div className="text-center">
         <h4 className="font-medium" style={{ fontFamily: "var(--font-display)" }}>
@@ -64,7 +64,7 @@ function SkillCard({ name, icon, level, category, className }: SkillCardProps) {
       {level && (
         <div className="w-full">
           <div className="bg-elevated h-1 w-full overflow-hidden">
-            <motion.div
+            <m.div
               className={cn("h-full", levelColors[level])}
               initial={{ width: 0 }}
               animate={{ width: isHovered ? levelWidths[level] : "0%" }}
@@ -76,7 +76,7 @@ function SkillCard({ name, icon, level, category, className }: SkillCardProps) {
       )}
 
       {isHovered && (
-        <motion.div
+        <m.div
           className="pointer-events-none absolute inset-0"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -88,7 +88,7 @@ function SkillCard({ name, icon, level, category, className }: SkillCardProps) {
           aria-hidden="true"
         />
       )}
-    </motion.div>
+    </m.div>
   );
 }
 

--- a/components/common/Textarea/textarea.test.tsx
+++ b/components/common/Textarea/textarea.test.tsx
@@ -23,21 +23,25 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <label {...filterMotionProps(props)}>{children}</label>
-    ),
-    textarea: React.forwardRef(
-      (props: Record<string, unknown>, ref: React.Ref<HTMLTextAreaElement>) => (
-        <textarea ref={ref} {...filterMotionProps(props)} />
-      )
-    ),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-  },
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      label: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <label {...filterMotionProps(props)}>{children}</label>
+      ),
+      textarea: React.forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLTextAreaElement>) => (
+          <textarea ref={ref} {...filterMotionProps(props)} />
+        )
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+    },
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { Textarea } from "./textarea";
 

--- a/components/common/Textarea/textarea.tsx
+++ b/components/common/Textarea/textarea.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef, useState } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "@/utils";
 
 interface TextareaProps {
@@ -51,7 +51,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     return (
       <div className={cn("relative", className)}>
-        <motion.label
+        <m.label
           htmlFor={name}
           className={cn(
             "text-muted pointer-events-none absolute left-4 origin-left transition-colors",
@@ -70,9 +70,9 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         >
           {label}
           {required && <span className="text-accent ml-1">*</span>}
-        </motion.label>
+        </m.label>
 
-        <motion.textarea
+        <m.textarea
           ref={ref}
           id={name}
           name={name}
@@ -101,7 +101,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         />
 
         {error && (
-          <motion.p
+          <m.p
             className="mt-1.5 text-sm text-red-500"
             initial={{ opacity: 0, y: -4 }}
             animate={{ opacity: 1, y: 0 }}
@@ -109,7 +109,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             role="alert"
           >
             {error}
-          </motion.p>
+          </m.p>
         )}
       </div>
     );

--- a/components/common/Toast/toast.test.tsx
+++ b/components/common/Toast/toast.test.tsx
@@ -23,14 +23,18 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("lucide-react", () => ({
   X: ({ className }: { className?: string }) => <svg data-testid="x-icon" className={className} />,

--- a/components/common/Toast/toast.tsx
+++ b/components/common/Toast/toast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { m, AnimatePresence } from "framer-motion";
 import { X, CheckCircle, AlertCircle, Info } from "lucide-react";
 import { cn } from "@/utils";
 
@@ -107,7 +107,7 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
   const Icon = config.icon;
 
   return (
-    <motion.div
+    <m.div
       layout
       initial={{ opacity: 0, y: 20, scale: 0.95 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -127,6 +127,6 @@ function ToastItem({ toast, onDismiss }: ToastItemProps) {
       >
         <X className="h-4 w-4" />
       </button>
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/custom/AnimatedLink/animated-link.test.tsx
+++ b/components/custom/AnimatedLink/animated-link.test.tsx
@@ -23,16 +23,20 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    svg: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <svg {...filterMotionProps(props)}>{children}</svg>
-    ),
-  },
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      svg: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <svg {...filterMotionProps(props)}>{children}</svg>
+      ),
+    },
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/link", () => ({
   __esModule: true,

--- a/components/custom/AnimatedLink/animated-link.tsx
+++ b/components/custom/AnimatedLink/animated-link.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef } from "react";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import Link from "next/link";
 
 interface AnimatedLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -22,7 +22,7 @@ const AnimatedLink = forwardRef<HTMLAnchorElement, AnimatedLinkProps>(
       "relative inline-flex items-center gap-1 text-accent transition-colors hover:text-accent-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none";
 
     const content = (
-      <motion.span
+      <m.span
         className={`${baseStyles} ${className}`}
         initial="rest"
         whileHover="hover"
@@ -31,7 +31,7 @@ const AnimatedLink = forwardRef<HTMLAnchorElement, AnimatedLinkProps>(
         <span className="relative">
           {children}
           {underlineStyle === "slide" && (
-            <motion.span
+            <m.span
               className="absolute bottom-0 left-0 h-[1px] bg-current"
               variants={{
                 rest: { width: 0 },
@@ -41,7 +41,7 @@ const AnimatedLink = forwardRef<HTMLAnchorElement, AnimatedLinkProps>(
             />
           )}
           {underlineStyle === "fade" && (
-            <motion.span
+            <m.span
               className="absolute bottom-0 left-0 h-[1px] w-full bg-current"
               variants={{
                 rest: { opacity: 0 },
@@ -52,7 +52,7 @@ const AnimatedLink = forwardRef<HTMLAnchorElement, AnimatedLinkProps>(
           )}
         </span>
         {external && (
-          <motion.svg
+          <m.svg
             className="h-4 w-4"
             viewBox="0 0 24 24"
             fill="none"
@@ -67,9 +67,9 @@ const AnimatedLink = forwardRef<HTMLAnchorElement, AnimatedLinkProps>(
             transition={{ duration: 0.2 }}
           >
             <path d="M7 17L17 7M17 7H7M17 7V17" />
-          </motion.svg>
+          </m.svg>
         )}
-      </motion.span>
+      </m.span>
     );
 
     if (external) {

--- a/components/custom/CursorEffects/cursor-effects.tsx
+++ b/components/custom/CursorEffects/cursor-effects.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useEffect } from "react";
-import { motion, useMotionValue, useSpring, useReducedMotion } from "framer-motion";
+import { m, useMotionValue, useSpring, useReducedMotion } from "framer-motion";
 import { useIsTouchDevice } from "@/hooks";
 import { useTheme } from "@/contexts";
 
@@ -150,7 +150,7 @@ export function CursorGlow() {
       className="pointer-events-none absolute inset-0 z-30 overflow-hidden"
       aria-hidden="true"
     >
-      <motion.div
+      <m.div
         className="absolute h-[400px] w-[400px] rounded-full"
         style={{
           left: smoothX,

--- a/components/custom/CustomCursor/custom-cursor.test.tsx
+++ b/components/custom/CustomCursor/custom-cursor.test.tsx
@@ -5,17 +5,21 @@ jest.mock("@/contexts", () => ({
   useTheme: () => ({ theme: "dark", toggleTheme: jest.fn() }),
 }));
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, className }: { children?: React.ReactNode; className: string }) => (
-      <div className={className} data-testid="cursor-element">
-        {children}
-      </div>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn() }),
-  useSpring: () => ({ set: jest.fn() }),
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, className }: { children?: React.ReactNode; className: string }) => (
+        <div className={className} data-testid="cursor-element">
+          {children}
+        </div>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn() }),
+    useSpring: () => ({ set: jest.fn() }),
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("CustomCursor", () => {
   const originalMatchMedia = window.matchMedia;

--- a/components/custom/CustomCursor/custom-cursor.tsx
+++ b/components/custom/CustomCursor/custom-cursor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { motion, useMotionValue, useSpring } from "framer-motion";
+import { m, useMotionValue, useSpring } from "framer-motion";
 import { useTheme } from "@/contexts";
 
 type CursorState = "default" | "hover" | "magnetic" | "text" | "hidden";
@@ -237,7 +237,7 @@ export function CustomCursor() {
 
   return (
     <>
-      <motion.div
+      <m.div
         className={`pointer-events-none fixed top-0 left-0 z-[9999] ${isDark && !isOverCurtain ? "bg-accent mix-blend-difference" : ""}`}
         style={{
           x: dotX,
@@ -255,7 +255,7 @@ export function CustomCursor() {
         transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
       />
 
-      <motion.div
+      <m.div
         className={`pointer-events-none fixed top-0 left-0 z-[9998] border-2 ${isDark && !isOverCurtain ? "border-accent/50 mix-blend-difference" : ""}`}
         style={{
           x: circleX,

--- a/components/custom/HoverCard/hover-card.test.tsx
+++ b/components/custom/HoverCard/hover-card.test.tsx
@@ -25,21 +25,25 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: React.forwardRef(
-      (
-        { children, ...props }: React.PropsWithChildren<Record<string, unknown>>,
-        ref: React.Ref<HTMLDivElement>
-      ) => (
-        <div ref={ref} {...filterMotionProps(props)}>
-          {children}
-        </div>
-      )
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: React.forwardRef(
+        (
+          { children, ...props }: React.PropsWithChildren<Record<string, unknown>>,
+          ref: React.Ref<HTMLDivElement>
+        ) => (
+          <div ref={ref} {...filterMotionProps(props)}>
+            {children}
+          </div>
+        )
+      ),
+    },
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { HoverCard } from "./hover-card";
 

--- a/components/custom/HoverCard/hover-card.tsx
+++ b/components/custom/HoverCard/hover-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { forwardRef, useState } from "react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 
 interface HoverCardProps {
   children: React.ReactNode;
@@ -17,7 +17,7 @@ const HoverCard = forwardRef<HTMLDivElement, HoverCardProps>(
     const shouldReduceMotion = useReducedMotion();
 
     return (
-      <motion.div
+      <m.div
         ref={ref}
         className={`border-border bg-surface relative border p-6 ${className}`}
         onMouseEnter={() => setIsHovered(true)}
@@ -37,7 +37,7 @@ const HoverCard = forwardRef<HTMLDivElement, HoverCardProps>(
         }}
       >
         {glowOnHover && (
-          <motion.div
+          <m.div
             className="pointer-events-none absolute inset-0"
             aria-hidden="true"
             style={{
@@ -51,7 +51,7 @@ const HoverCard = forwardRef<HTMLDivElement, HoverCardProps>(
           />
         )}
         <div className="relative z-10">{children}</div>
-      </motion.div>
+      </m.div>
     );
   }
 );

--- a/components/custom/MagneticButton/magnetic-button.test.tsx
+++ b/components/custom/MagneticButton/magnetic-button.test.tsx
@@ -1,56 +1,60 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MagneticButton } from "./magnetic-button";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({
-      children,
-      className,
-      onMouseMove,
-      onMouseEnter,
-      onMouseLeave,
-    }: {
-      children: React.ReactNode;
-      className?: string;
-      onMouseMove?: () => void;
-      onMouseEnter?: () => void;
-      onMouseLeave?: () => void;
-    }) => (
-      <div
-        className={className}
-        onMouseMove={onMouseMove}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
-        {children}
-      </div>
-    ),
-    button: ({
-      children,
-      onClick,
-      className,
-      disabled,
-      type,
-      ref,
-    }: {
-      children: React.ReactNode;
-      onClick?: () => void;
-      className?: string;
-      disabled?: boolean;
-      type?: string;
-      ref?: React.Ref<HTMLButtonElement>;
-    }) => (
-      <button ref={ref} onClick={onClick} className={className} disabled={disabled} type={type}>
-        {children}
-      </button>
-    ),
-    span: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-      <span className={className}>{children}</span>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn(), get: () => 0 }),
-  useSpring: () => ({ set: jest.fn() }),
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({
+        children,
+        className,
+        onMouseMove,
+        onMouseEnter,
+        onMouseLeave,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+        onMouseMove?: () => void;
+        onMouseEnter?: () => void;
+        onMouseLeave?: () => void;
+      }) => (
+        <div
+          className={className}
+          onMouseMove={onMouseMove}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          {children}
+        </div>
+      ),
+      button: ({
+        children,
+        onClick,
+        className,
+        disabled,
+        type,
+        ref,
+      }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+        className?: string;
+        disabled?: boolean;
+        type?: string;
+        ref?: React.Ref<HTMLButtonElement>;
+      }) => (
+        <button ref={ref} onClick={onClick} className={className} disabled={disabled} type={type}>
+          {children}
+        </button>
+      ),
+      span: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+        <span className={className}>{children}</span>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn(), get: () => 0 }),
+    useSpring: () => ({ set: jest.fn() }),
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("MagneticButton", () => {
   it("renders children", () => {

--- a/components/custom/MagneticButton/magnetic-button.tsx
+++ b/components/custom/MagneticButton/magnetic-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, forwardRef } from "react";
-import { motion, useMotionValue, useSpring } from "framer-motion";
+import { m, useMotionValue, useSpring } from "framer-motion";
 
 interface MagneticButtonProps {
   children: React.ReactNode;
@@ -78,7 +78,7 @@ const MagneticButton = forwardRef<HTMLButtonElement, MagneticButtonProps>(
     };
 
     return (
-      <motion.div
+      <m.div
         ref={buttonRef}
         style={{ x: springX, y: springY }}
         onMouseMove={handleMouseMove}
@@ -86,7 +86,7 @@ const MagneticButton = forwardRef<HTMLButtonElement, MagneticButtonProps>(
         onMouseLeave={handleMouseLeave}
         className="inline-block"
       >
-        <motion.button
+        <m.button
           ref={ref}
           type={type}
           disabled={disabled}
@@ -100,14 +100,14 @@ const MagneticButton = forwardRef<HTMLButtonElement, MagneticButtonProps>(
           }}
           transition={{ duration: 0.2 }}
         >
-          <motion.span
+          <m.span
             style={{ x: springX, y: springY }}
             className="relative z-10 flex items-center justify-center"
           >
             {children}
-          </motion.span>
-        </motion.button>
-      </motion.div>
+          </m.span>
+        </m.button>
+      </m.div>
     );
   }
 );

--- a/components/custom/MotionProvider/index.ts
+++ b/components/custom/MotionProvider/index.ts
@@ -1,0 +1,1 @@
+export { default as MotionProvider } from "./motion-provider";

--- a/components/custom/MotionProvider/motion-provider.tsx
+++ b/components/custom/MotionProvider/motion-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { LazyMotion, domMax } from "framer-motion";
+
+interface MotionProviderProps {
+  children: ReactNode;
+}
+
+export default function MotionProvider({ children }: MotionProviderProps) {
+  return (
+    <LazyMotion features={domMax} strict>
+      {children}
+    </LazyMotion>
+  );
+}

--- a/components/custom/PageTransition/page-transition.test.tsx
+++ b/components/custom/PageTransition/page-transition.test.tsx
@@ -22,14 +22,18 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+    },
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 import { PageTransition, PageTransitionItem } from "./page-transition";
 

--- a/components/custom/PageTransition/page-transition.tsx
+++ b/components/custom/PageTransition/page-transition.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -11,7 +11,7 @@ export function PageTransition({ children, className = "" }: PageTransitionProps
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.div
+    <m.div
       className={className}
       initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
       animate={{
@@ -32,7 +32,7 @@ export function PageTransition({ children, className = "" }: PageTransitionProps
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -45,7 +45,7 @@ export function PageTransitionItem({ children, className = "" }: PageTransitionI
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.div
+    <m.div
       className={className}
       initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
       animate={{
@@ -58,6 +58,6 @@ export function PageTransitionItem({ children, className = "" }: PageTransitionI
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/custom/ProximityShape/proximity-shape.test.tsx
+++ b/components/custom/ProximityShape/proximity-shape.test.tsx
@@ -3,29 +3,33 @@ import { ProximityShape } from "./proximity-shape";
 
 import type { ProximityShapeData } from "./proximity-shape";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({
-      children,
-      className,
-      "aria-hidden": ariaHidden,
-      style,
-    }: {
-      children?: React.ReactNode;
-      className?: string;
-      "aria-hidden"?: string;
-      style?: React.CSSProperties;
-    }) => (
-      <div className={className} aria-hidden={ariaHidden} style={style}>
-        {children}
-      </div>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn(), get: () => 0, on: () => () => {} }),
-  useSpring: () => ({ set: jest.fn(), get: () => 0 }),
-  useReducedMotion: () => false,
-  useTransform: () => ({ set: jest.fn(), get: () => 0 }),
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({
+        children,
+        className,
+        "aria-hidden": ariaHidden,
+        style,
+      }: {
+        children?: React.ReactNode;
+        className?: string;
+        "aria-hidden"?: string;
+        style?: React.CSSProperties;
+      }) => (
+        <div className={className} aria-hidden={ariaHidden} style={style}>
+          {children}
+        </div>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn(), get: () => 0, on: () => () => {} }),
+    useSpring: () => ({ set: jest.fn(), get: () => 0 }),
+    useReducedMotion: () => false,
+    useTransform: () => ({ set: jest.fn(), get: () => 0 }),
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 const mockMouseX = { set: jest.fn(), get: () => 0, on: () => () => {} };
 const mockMouseY = { set: jest.fn(), get: () => 0, on: () => () => {} };

--- a/components/custom/ProximityShape/proximity-shape.tsx
+++ b/components/custom/ProximityShape/proximity-shape.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import {
-  motion,
+  m,
   useMotionValue,
   useSpring,
   useReducedMotion,
@@ -131,7 +131,7 @@ export function ProximityShape({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className="pointer-events-none absolute"
       style={{
@@ -144,7 +144,7 @@ export function ProximityShape({
       }}
       aria-hidden="true"
     >
-      <motion.div
+      <m.div
         animate={shouldReduceMotion ? {} : { y: [0, -10, 0], x: [0, 5, -5, 0] }}
         transition={{
           duration: shape.floatDuration,
@@ -154,7 +154,7 @@ export function ProximityShape({
         }}
       >
         {renderShape()}
-      </motion.div>
-    </motion.div>
+      </m.div>
+    </m.div>
   );
 }

--- a/components/custom/TextReveal/text-reveal.test.tsx
+++ b/components/custom/TextReveal/text-reveal.test.tsx
@@ -1,18 +1,22 @@
 import { render, screen } from "@testing-library/react";
 import { AnimatedText, FadeIn, StaggerContainer, StaggerItem } from "./text-reveal";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    span: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
-      <span className={className}>{children}</span>
-    ),
-    div: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
-      <div className={className}>{children}</div>
-    ),
-  },
-  useInView: () => true,
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      span: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <span className={className}>{children}</span>
+      ),
+      div: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <div className={className}>{children}</div>
+      ),
+    },
+    useInView: () => true,
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("AnimatedText", () => {
   it("renders the text content", () => {

--- a/components/custom/TextReveal/text-reveal.tsx
+++ b/components/custom/TextReveal/text-reveal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import { motion, useInView, useReducedMotion } from "framer-motion";
+import { m, useInView, useReducedMotion } from "framer-motion";
 
 interface AnimatedTextProps {
   children: string;
@@ -39,7 +39,7 @@ export function AnimatedText({
       style={style}
     >
       {items.map((item, index) => (
-        <motion.span
+        <m.span
           key={index}
           className="inline-block"
           initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
@@ -56,7 +56,7 @@ export function AnimatedText({
         >
           {item}
           {splitBy === "words" && index < items.length - 1 ? "\u00A0" : ""}
-        </motion.span>
+        </m.span>
       ))}
     </Component>
   );
@@ -102,7 +102,7 @@ export function FadeIn({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={className}
       initial={{ opacity: shouldReduceMotion ? 1 : 0, ...getInitialPosition() }}
@@ -118,7 +118,7 @@ export function FadeIn({
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -142,7 +142,7 @@ export function StaggerContainer({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={className}
       initial={shouldReduceMotion ? "visible" : "hidden"}
@@ -158,7 +158,7 @@ export function StaggerContainer({
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -172,7 +172,7 @@ export function StaggerItem({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <motion.div
+    <m.div
       className={className}
       variants={{
         hidden: { opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 },
@@ -187,6 +187,6 @@ export function StaggerItem({
       }}
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }

--- a/components/custom/ThemeToggle/theme-toggle.test.tsx
+++ b/components/custom/ThemeToggle/theme-toggle.test.tsx
@@ -11,33 +11,37 @@ jest.mock("@/contexts", () => ({
   }),
 }));
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    button: ({
-      children,
-      onClick,
-      className,
-      "aria-label": ariaLabel,
-    }: {
-      children: React.ReactNode;
-      onClick: () => void;
-      className: string;
-      "aria-label": string;
-    }) => (
-      <button onClick={onClick} className={className} aria-label={ariaLabel}>
-        {children}
-      </button>
-    ),
-    div: ({ children, className }: { children: React.ReactNode; className: string }) => (
-      <div className={className}>{children}</div>
-    ),
-    svg: ({ children, className }: { children: React.ReactNode; className: string }) => (
-      <svg className={className}>{children}</svg>
-    ),
-  },
-  useMotionValue: () => ({ set: jest.fn() }),
-  useSpring: () => ({ set: jest.fn() }),
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      button: ({
+        children,
+        onClick,
+        className,
+        "aria-label": ariaLabel,
+      }: {
+        children: React.ReactNode;
+        onClick: () => void;
+        className: string;
+        "aria-label": string;
+      }) => (
+        <button onClick={onClick} className={className} aria-label={ariaLabel}>
+          {children}
+        </button>
+      ),
+      div: ({ children, className }: { children: React.ReactNode; className: string }) => (
+        <div className={className}>{children}</div>
+      ),
+      svg: ({ children, className }: { children: React.ReactNode; className: string }) => (
+        <svg className={className}>{children}</svg>
+      ),
+    },
+    useMotionValue: () => ({ set: jest.fn() }),
+    useSpring: () => ({ set: jest.fn() }),
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("ThemeToggle", () => {
   beforeEach(() => {

--- a/components/custom/ThemeToggle/theme-toggle.tsx
+++ b/components/custom/ThemeToggle/theme-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useCallback } from "react";
-import { motion, useMotionValue, useSpring } from "framer-motion";
+import { m, useMotionValue, useSpring } from "framer-motion";
 import { useTheme } from "@/contexts";
 
 interface ThemeToggleProps {
@@ -110,7 +110,7 @@ export function ThemeToggle({
   }, [toggleTheme]);
 
   return (
-    <motion.button
+    <m.button
       ref={buttonRef}
       onClick={handleToggle}
       onMouseMove={handleMouseMove}
@@ -125,7 +125,7 @@ export function ThemeToggle({
       whileTap={{ scale: 0.95 }}
       aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
     >
-      <motion.div
+      <m.div
         className="relative h-5 w-5"
         initial={false}
         animate={{ rotate: theme === "dark" ? 0 : 180 }}
@@ -137,7 +137,7 @@ export function ThemeToggle({
         }}
       >
         {/* Sun */}
-        <motion.svg
+        <m.svg
           className="text-foreground absolute inset-0 h-5 w-5"
           viewBox="0 0 24 24"
           fill="none"
@@ -161,10 +161,10 @@ export function ThemeToggle({
           <line x1="21" y1="12" x2="23" y2="12" />
           <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
           <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-        </motion.svg>
+        </m.svg>
 
         {/* Moon */}
-        <motion.svg
+        <m.svg
           className="text-foreground absolute inset-0 h-5 w-5"
           viewBox="0 0 24 24"
           fill="none"
@@ -180,8 +180,8 @@ export function ThemeToggle({
           transition={{ duration: 0.3 }}
         >
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </motion.svg>
-      </motion.div>
-    </motion.button>
+        </m.svg>
+      </m.div>
+    </m.button>
   );
 }

--- a/components/custom/home/About/about.test.tsx
+++ b/components/custom/home/About/about.test.tsx
@@ -42,29 +42,33 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-    section: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <section {...filterMotionProps(props)}>{children}</section>
-    ),
-  },
-  useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
-  useTransform: () => ({ get: () => 0 }),
-  useSpring: () => ({ get: () => 0, set: () => {} }),
-  useMotionValue: () => ({ get: () => 0, set: () => {} }),
-  useReducedMotion: () => false,
-  useInView: () => true,
-  useAnimationFrame: () => {},
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+      section: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <section {...filterMotionProps(props)}>{children}</section>
+      ),
+    },
+    useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+    useTransform: () => ({ get: () => 0 }),
+    useSpring: () => ({ get: () => 0, set: () => {} }),
+    useMotionValue: () => ({ get: () => 0, set: () => {} }),
+    useReducedMotion: () => false,
+    useInView: () => true,
+    useAnimationFrame: () => {},
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/components/custom/home/About/about.tsx
+++ b/components/custom/home/About/about.tsx
@@ -3,7 +3,7 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import Image from "next/image";
 import {
-  motion,
+  m,
   useScroll,
   useTransform,
   useSpring,
@@ -39,13 +39,13 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
     <header className="border-foreground/[0.08] border-y py-8 sm:py-12 md:py-16 lg:py-20">
       <div className="mx-auto w-full max-w-7xl px-4 sm:px-6">
         {/* Section tag — matches Projects pattern */}
-        <motion.div
+        <m.div
           className="mb-4 overflow-clip"
           initial={{ width: shouldReduceMotion ? "auto" : 0 }}
           animate={isInView ? { width: "auto" } : {}}
           transition={{ duration: 0.8, ease: EASE }}
         >
-          <motion.span
+          <m.span
             className="text-foreground inline-block px-3 py-1.5 text-xs font-bold tracking-[0.2em] sm:px-4 sm:py-2"
             style={{ backgroundColor: ACCENT_HEX, fontFamily: "var(--font-display)" }}
             initial={{ x: shouldReduceMotion ? 0 : -100 }}
@@ -53,8 +53,8 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
             transition={{ duration: 0.6, delay: 0.3, ease: EASE }}
           >
             {t("badge")}
-          </motion.span>
-        </motion.div>
+          </m.span>
+        </m.div>
 
         <h2
           id="about-heading"
@@ -68,7 +68,7 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
                 .filter(Boolean)
                 .join(" ")}
             >
-              <motion.span
+              <m.span
                 className="inline-block"
                 style={{ color: i === 1 ? ACCENT_HEX : "inherit" }}
                 initial={{ y: shouldReduceMotion ? 0 : "100%" }}
@@ -76,20 +76,20 @@ function SectionHeader({ isInView }: { isInView: boolean }) {
                 transition={{ duration: 0.6, delay: 0.3 + i * 0.15, ease: EASE }}
               >
                 {word}
-              </motion.span>
+              </m.span>
               {i === 0 && <br className="md:hidden" />}
             </span>
           ))}
         </h2>
 
-        <motion.p
+        <m.p
           className="text-foreground/80 max-w-xl text-sm sm:text-base lg:text-lg"
           initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.8, delay: 0.6, ease: EASE }}
         >
           {t("description")}
-        </motion.p>
+        </m.p>
       </div>
     </header>
   );
@@ -255,7 +255,7 @@ function RailShape({
   }, [scale]);
 
   return (
-    <motion.div
+    <m.div
       className={`pointer-events-auto absolute cursor-grab active:cursor-grabbing ${config.className}`}
       style={{
         width: config.size,
@@ -372,10 +372,7 @@ export default function About() {
       <div className="mx-auto w-full max-w-7xl px-4 pt-8 sm:px-6 sm:pt-10 md:pt-12">
         <div className="relative flex flex-col-reverse gap-8 sm:gap-10 md:gap-12 lg:flex-row lg:gap-20">
           {/* Left: Scroll-driven word reveal */}
-          <motion.div
-            className="flex w-full flex-col justify-center lg:w-[55%]"
-            style={{ y: textY }}
-          >
+          <m.div className="flex w-full flex-col justify-center lg:w-[55%]" style={{ y: textY }}>
             <p className="sr-only">{t("bio")}</p>
             <p
               className="text-xl leading-snug font-black sm:text-2xl md:text-3xl lg:text-4xl"
@@ -399,7 +396,7 @@ export default function About() {
             </p>
 
             {/* Scroll hint */}
-            <motion.div
+            <m.div
               className="mt-8 flex items-center gap-3 sm:mt-10 md:mt-12"
               style={{ color: "var(--color-muted)" }}
               initial={{ opacity: 0 }}
@@ -407,24 +404,24 @@ export default function About() {
               transition={{ delay: 1.5 }}
               aria-hidden="true"
             >
-              <motion.div
+              <m.div
                 animate={shouldReduceMotion ? {} : { y: [0, 6, 0] }}
                 transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
               >
                 <ArrowDown className="h-4 w-4" />
-              </motion.div>
+              </m.div>
               <span
                 className="text-xs font-medium tracking-widest uppercase"
                 style={{ fontFamily: "var(--font-mono)" }}
               >
                 {t("scrollHint")}
               </span>
-            </motion.div>
-          </motion.div>
+            </m.div>
+          </m.div>
 
           {/* Right: Photo with bottom-up clip-path reveal */}
-          <motion.div className="relative w-full lg:w-[45%]" style={{ y: photoY }}>
-            <motion.div
+          <m.div className="relative w-full lg:w-[45%]" style={{ y: photoY }}>
+            <m.div
               className="relative aspect-[3/4] w-full overflow-hidden"
               initial={{ clipPath: shouldReduceMotion ? "inset(0 0 0 0)" : "inset(100% 0 0 0)" }}
               animate={isInView ? { clipPath: "inset(0 0 0 0)" } : {}}
@@ -438,10 +435,10 @@ export default function About() {
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 100vw, 45vw"
                 priority
               />
-            </motion.div>
+            </m.div>
 
             <RailShapesContainer isInView={isInView} />
-          </motion.div>
+          </m.div>
         </div>
       </div>
     </section>
@@ -479,12 +476,12 @@ function ScrollWord({
   const isHighlight = highlights.includes(word);
 
   return (
-    <motion.span
+    <m.span
       className="mr-[0.3em] inline-block"
       style={{ opacity, color: isHighlight ? ACCENT_HEX : color }}
       aria-hidden="true"
     >
       {word}
-    </motion.span>
+    </m.span>
   );
 }

--- a/components/custom/home/Contact/contact.test.tsx
+++ b/components/custom/home/Contact/contact.test.tsx
@@ -29,34 +29,38 @@ const filterMotionProps = (props: Record<string, unknown>) => {
   return filtered;
 };
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <p {...filterMotionProps(props)}>{children}</p>
-    ),
-    section: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <section {...filterMotionProps(props)}>{children}</section>
-    ),
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...filterMotionProps(props)}>{children}</button>
-    ),
-    a: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <a {...filterMotionProps(props)}>{children}</a>
-    ),
-  },
-  useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
-  useTransform: () => ({ get: () => 0 }),
-  useSpring: () => ({ get: () => 0, set: () => {} }),
-  useMotionValue: () => ({ get: () => 0, set: () => {} }),
-  useReducedMotion: () => false,
-  useInView: () => true,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      p: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <p {...filterMotionProps(props)}>{children}</p>
+      ),
+      section: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <section {...filterMotionProps(props)}>{children}</section>
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...filterMotionProps(props)}>{children}</button>
+      ),
+      a: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <a {...filterMotionProps(props)}>{children}</a>
+      ),
+    },
+    useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+    useTransform: () => ({ get: () => 0 }),
+    useSpring: () => ({ get: () => 0, set: () => {} }),
+    useMotionValue: () => ({ get: () => 0, set: () => {} }),
+    useReducedMotion: () => false,
+    useInView: () => true,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("lucide-react", () => ({
   Github: ({ className }: any) => <svg data-testid="github-icon" className={className} />,

--- a/components/custom/home/Contact/contact.tsx
+++ b/components/custom/home/Contact/contact.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from "react";
 import {
-  motion,
+  m,
   useScroll,
   useTransform,
   useSpring,
@@ -78,7 +78,7 @@ function Magnetic3DWrapper({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={className}
       style={{ x: springX, y: springY }}
@@ -91,7 +91,7 @@ function Magnetic3DWrapper({
       transition={{ duration: 0.2 }}
     >
       {children(springX, springY)}
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -112,7 +112,7 @@ function CopyEmailButton() {
   return (
     <Magnetic3DWrapper className="inline-block">
       {(springX, springY) => (
-        <motion.button
+        <m.button
           onClick={handleCopy}
           className="group flex items-center gap-2 border-2 px-3 py-2 text-xs font-semibold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:px-4 sm:py-2.5 sm:text-sm md:px-5 md:py-3 md:text-base"
           style={{
@@ -135,7 +135,7 @@ function CopyEmailButton() {
           whileTap={{ scale: 0.97 }}
           transition={{ duration: 0.15 }}
         >
-          <motion.span className="flex items-center gap-2" style={{ x: springX, y: springY }}>
+          <m.span className="flex items-center gap-2" style={{ x: springX, y: springY }}>
             {copied ? (
               <>
                 <Check className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
@@ -147,8 +147,8 @@ function CopyEmailButton() {
                 {EMAIL}
               </>
             )}
-          </motion.span>
-        </motion.button>
+          </m.span>
+        </m.button>
       )}
     </Magnetic3DWrapper>
   );
@@ -170,7 +170,7 @@ function SocialLinkButton({
   return (
     <Magnetic3DWrapper className="inline-block">
       {(springX, springY) => (
-        <motion.a
+        <m.a
           href={href}
           target="_blank"
           rel="noopener noreferrer"
@@ -188,13 +188,10 @@ function SocialLinkButton({
           whileTap={{ scale: 0.95 }}
           transition={{ duration: 0.15 }}
         >
-          <motion.span
-            className="flex items-center justify-center"
-            style={{ x: springX, y: springY }}
-          >
+          <m.span className="flex items-center justify-center" style={{ x: springX, y: springY }}>
             <Icon className="h-4 w-4 sm:h-[18px] sm:w-[18px] md:h-5 md:w-5" />
-          </motion.span>
-        </motion.a>
+          </m.span>
+        </m.a>
       )}
     </Magnetic3DWrapper>
   );
@@ -236,10 +233,7 @@ export default function Contact() {
       <GridBackground id="contact-grid" />
       <CursorBrightGrid cellSize={100} maxOpacity={0.15} />
 
-      <motion.div
-        className="relative mx-auto w-full max-w-7xl px-4 sm:px-6"
-        style={{ y: contentY }}
-      >
+      <m.div className="relative mx-auto w-full max-w-7xl px-4 sm:px-6" style={{ y: contentY }}>
         <h2 id="contact-heading" className="sr-only">
           Contact
         </h2>
@@ -248,7 +242,7 @@ export default function Contact() {
         <div className="mb-16 space-y-0.5 sm:mb-20 sm:space-y-1 md:mb-24 md:space-y-2 lg:mb-28 lg:space-y-3">
           {manifesto.map((line, i) => (
             <div key={i} className="overflow-hidden">
-              <motion.p
+              <m.p
                 className="text-3xl font-black sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
                 style={{ fontFamily: "var(--font-display)", color: line.color }}
                 initial={{ y: shouldReduceMotion ? 0 : "100%" }}
@@ -256,13 +250,13 @@ export default function Contact() {
                 transition={{ duration: 0.7, delay: 0.6 + i * 0.12, ease: EASE }}
               >
                 {line.text}
-              </motion.p>
+              </m.p>
             </div>
           ))}
         </div>
 
         {/* Actions row */}
-        <motion.div
+        <m.div
           className="flex flex-col items-start gap-4 pb-6 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:pb-8 md:pb-10 lg:pb-12"
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
@@ -280,25 +274,25 @@ export default function Contact() {
               />
             ))}
           </nav>
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
 
       {/* Floating decorative shapes */}
-      <motion.div
+      <m.div
         className="absolute top-[12%] right-[6%] h-6 w-6 rotate-45 sm:top-[15%] sm:right-[8%] sm:h-8 sm:w-8 md:h-10 md:w-10"
         style={{ backgroundColor: `${ACCENT_HEX}12` }}
         animate={shouldReduceMotion ? {} : { y: [0, -12, 0] }}
         transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }}
         aria-hidden="true"
       />
-      <motion.div
+      <m.div
         className="absolute bottom-[15%] left-[4%] h-5 w-5 rounded-full sm:bottom-[20%] sm:left-[6%] sm:h-6 sm:w-6 md:h-8 md:w-8"
         style={{ backgroundColor: `${PINK_HEX}10` }}
         animate={shouldReduceMotion ? {} : { y: [0, 10, 0] }}
         transition={{ duration: 7, repeat: Infinity, ease: "easeInOut" }}
         aria-hidden="true"
       />
-      <motion.div
+      <m.div
         className="absolute top-[40%] left-[3%] hidden h-5 w-5 sm:block md:h-6 md:w-6"
         style={{ backgroundColor: `${CYAN_HEX}08` }}
         animate={shouldReduceMotion ? {} : { rotate: [0, 90, 0] }}

--- a/components/custom/home/Experience/experience.test.tsx
+++ b/components/custom/home/Experience/experience.test.tsx
@@ -50,30 +50,34 @@ jest.mock("@/contexts", () => ({
   }),
 }));
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <div {...filterMotionProps(props)}>{children}</div>
-    ),
-    span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <span {...filterMotionProps(props)}>{children}</span>
-    ),
-    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <button {...filterMotionProps(props)}>{children}</button>
-    ),
-    li: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <li {...filterMotionProps(props)}>{children}</li>
-    ),
-    article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
-      <article {...filterMotionProps(props)}>{children}</article>
-    ),
-  },
-  useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
-  useTransform: () => ({ get: () => 0 }),
-  useSpring: () => ({ get: () => 0 }),
-  useMotionValue: () => ({ get: () => 0, set: () => {} }),
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <div {...filterMotionProps(props)}>{children}</div>
+      ),
+      span: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <span {...filterMotionProps(props)}>{children}</span>
+      ),
+      button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <button {...filterMotionProps(props)}>{children}</button>
+      ),
+      li: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <li {...filterMotionProps(props)}>{children}</li>
+      ),
+      article: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+        <article {...filterMotionProps(props)}>{children}</article>
+      ),
+    },
+    useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+    useTransform: () => ({ get: () => 0 }),
+    useSpring: () => ({ get: () => 0 }),
+    useMotionValue: () => ({ get: () => 0, set: () => {} }),
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 describe("Experience", () => {
   it("renders the section heading", () => {

--- a/components/custom/home/Experience/experience.tsx
+++ b/components/custom/home/Experience/experience.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  motion,
+  m,
   useScroll,
   useTransform,
   useSpring,
@@ -216,14 +216,14 @@ function ExperienceCard({
       className="group relative"
       aria-labelledby={`exp-${index}-title`}
     >
-      <motion.div
+      <m.div
         initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 80 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, margin: "-50px" }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.8, ease: EASE }}
       >
-        <motion.div className="relative" style={{ y: useParallax ? springNumberY : 0 }}>
-          <motion.span
+        <m.div className="relative" style={{ y: useParallax ? springNumberY : 0 }}>
+          <m.span
             className="pointer-events-none block text-[6rem] leading-none font-black sm:text-[8rem] md:text-[10rem] lg:text-[12rem] xl:text-[14rem]"
             style={{
               fontFamily: "var(--font-display)",
@@ -234,10 +234,10 @@ function ExperienceCard({
             aria-hidden="true"
           >
             {String(EXPERIENCES.length - index).padStart(2, "0")}
-          </motion.span>
-        </motion.div>
+          </m.span>
+        </m.div>
 
-        <motion.div
+        <m.div
           className="border-border relative -mt-12 border p-4 sm:-mt-14 sm:p-6 md:-mt-16 md:p-8 lg:-mt-20 lg:ml-4 xl:ml-8"
           style={{
             borderColor: isDark ? "#1f1f1f" : "#e5e5e5",
@@ -257,7 +257,7 @@ function ExperienceCard({
           </div>
 
           <div className="relative mb-2 inline-block sm:mb-3">
-            <motion.span
+            <m.span
               className="absolute -inset-x-2 -inset-y-1 sm:-inset-x-4 sm:-inset-y-2"
               style={{ backgroundColor: ACCENT, originX: 0 }}
               initial={{ scaleX: 0 }}
@@ -270,7 +270,7 @@ function ExperienceCard({
               className="relative z-10 text-xl font-black sm:text-2xl md:text-3xl lg:text-4xl"
               style={{ fontFamily: "var(--font-display)" }}
             >
-              <motion.span
+              <m.span
                 animate={{
                   color:
                     shouldReduceMotion || isActive
@@ -282,7 +282,7 @@ function ExperienceCard({
                 transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
               >
                 {exp.company.toUpperCase()}
-              </motion.span>
+              </m.span>
             </h3>
           </div>
 
@@ -299,7 +299,7 @@ function ExperienceCard({
             {t(`${exp.i18nKey}.description`)}
           </p>
 
-          <motion.div
+          <m.div
             className="overflow-hidden"
             initial={{
               height: shouldReduceMotion ? "auto" : 0,
@@ -315,7 +315,7 @@ function ExperienceCard({
               {Array.from({ length: exp.highlightCount }, (_, i) =>
                 t(`${exp.i18nKey}.highlights.${i}`)
               ).map((h, i) => (
-                <motion.li
+                <m.li
                   key={i}
                   className="text-foreground flex items-start gap-2 text-xs sm:gap-3 sm:text-sm"
                   initial={{ x: shouldReduceMotion ? 0 : -20, opacity: shouldReduceMotion ? 1 : 0 }}
@@ -331,10 +331,10 @@ function ExperienceCard({
                     aria-hidden="true"
                   />
                   {h}
-                </motion.li>
+                </m.li>
               ))}
             </ul>
-          </motion.div>
+          </m.div>
 
           <ul
             className="flex flex-wrap gap-1.5 pt-3 sm:gap-2 sm:pt-4"
@@ -342,7 +342,7 @@ function ExperienceCard({
             aria-label="Technologies used"
           >
             {exp.skills.map((skill, i) => (
-              <motion.li
+              <m.li
                 key={skill}
                 className="text-foreground border px-2 py-1 text-[10px] font-medium sm:px-3 sm:text-xs"
                 style={{
@@ -363,11 +363,11 @@ function ExperienceCard({
                 }
               >
                 {skill}
-              </motion.li>
+              </m.li>
             ))}
           </ul>
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
     </article>
   );
 }
@@ -456,7 +456,7 @@ export default function Experience() {
             className="relative z-10 flex h-full w-full flex-col justify-center p-6 pr-6 sm:p-8 sm:pr-8 xl:p-12 xl:pr-12"
             style={{ paddingLeft: "max(1.5rem, calc((100vw - 1280px) / 2 + 1rem))" }}
           >
-            <motion.div
+            <m.div
               initial={{ x: shouldReduceMotion ? 0 : -50, opacity: 0 }}
               whileInView={{ x: 0, opacity: 1 }}
               viewport={{ once: true }}
@@ -480,7 +480,7 @@ export default function Experience() {
               <p className="mt-2 max-w-xs text-sm leading-relaxed text-white/70 xl:mt-3 xl:text-base">
                 {t("description")}
               </p>
-            </motion.div>
+            </m.div>
           </div>
         </aside>
 

--- a/components/custom/home/Hero/hero.test.tsx
+++ b/components/custom/home/Hero/hero.test.tsx
@@ -61,44 +61,41 @@ jest.mock("framer-motion", () => {
     );
   });
 
-  return {
-    motion: {
-      section: MockSection,
-      div: MockDiv,
-      span: function MockSpan({
-        children,
-        className,
-        style,
-      }: {
-        children?: React.ReactNode;
-        className?: string;
-        style?: object;
-      }) {
-        return (
-          <span className={className} style={style}>
-            {children}
-          </span>
-        );
-      },
-      h1: function MockH1({
-        children,
-        className,
-      }: {
-        children: React.ReactNode;
-        className?: string;
-      }) {
-        return <h1 className={className}>{children}</h1>;
-      },
-      p: function MockP({
-        children,
-        className,
-      }: {
-        children: React.ReactNode;
-        className?: string;
-      }) {
-        return <p className={className}>{children}</p>;
-      },
+  const motion = {
+    section: MockSection,
+    div: MockDiv,
+    span: function MockSpan({
+      children,
+      className,
+      style,
+    }: {
+      children?: React.ReactNode;
+      className?: string;
+      style?: object;
+    }) {
+      return (
+        <span className={className} style={style}>
+          {children}
+        </span>
+      );
     },
+    h1: function MockH1({
+      children,
+      className,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+    }) {
+      return <h1 className={className}>{children}</h1>;
+    },
+    p: function MockP({ children, className }: { children: React.ReactNode; className?: string }) {
+      return <p className={className}>{children}</p>;
+    },
+  };
+
+  return {
+    motion,
+    m: motion,
     useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
     useTransform: () => 0,
     useSpring: () => ({ set: jest.fn(), get: () => 0 }),

--- a/components/custom/home/Hero/hero.tsx
+++ b/components/custom/home/Hero/hero.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useCallback, useEffect, useState } from "react";
 import {
-  motion,
+  m,
   useScroll,
   useTransform,
   useSpring,
@@ -209,11 +209,11 @@ function Hero() {
       )}
       {!isTouch && <CursorShapes enableMotion={enableMotion} />}
 
-      <motion.div
+      <m.div
         className="relative z-10 mx-auto flex w-full max-w-7xl flex-col items-center px-4 text-center sm:px-6"
         style={{ y: y1 }}
       >
-        <motion.div
+        <m.div
           className="hero-pills mb-8 flex flex-wrap justify-center gap-3"
           style={{ y: y2 }}
           role="list"
@@ -228,9 +228,9 @@ function Hero() {
               className={tech.showOnMobile ? "" : "hidden sm:flex"}
             />
           ))}
-        </motion.div>
+        </m.div>
 
-        <motion.div style={{ y: y3 }}>
+        <m.div style={{ y: y3 }}>
           <h1
             className="hero-title-1 text-foreground mb-2 text-6xl font-black tracking-tight sm:text-7xl md:text-8xl lg:text-9xl"
             style={{ fontFamily: "var(--font-display)" }}
@@ -250,7 +250,7 @@ function Hero() {
               />
             </span>
           </h1>
-        </motion.div>
+        </m.div>
 
         <p
           className="hero-tagline text-foreground/80 mb-12 max-w-lg text-xl md:text-2xl md:whitespace-nowrap"
@@ -289,16 +289,16 @@ function Hero() {
             </MagneticButton>
           </a>
         </div>
-      </motion.div>
+      </m.div>
 
-      <motion.div
+      <m.div
         className="absolute bottom-8 left-1/2 z-20 -translate-x-1/2"
         initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: shouldReduceMotion ? 0 : 2.2 }}
         aria-hidden="true"
       >
-        <motion.div
+        <m.div
           className="text-muted flex flex-col items-center gap-2"
           animate={shouldReduceMotion ? {} : { y: [0, 8, 0] }}
           transition={
@@ -307,8 +307,8 @@ function Hero() {
         >
           <span className="text-xs tracking-widest uppercase">{t("scroll")}</span>
           <div className="from-muted h-8 w-px bg-gradient-to-b to-transparent" />
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
     </section>
   );
 }
@@ -411,7 +411,7 @@ function MagneticPill({
   };
 
   return (
-    <motion.div
+    <m.div
       ref={ref}
       className={`magnetic ${className}`}
       role="listitem"
@@ -426,7 +426,7 @@ function MagneticPill({
         duration: shouldReduceMotion ? 0 : 0.4,
       }}
     >
-      <motion.div
+      <m.div
         className="focus-visible:ring-accent focus-visible:ring-offset-background flex cursor-pointer items-center gap-2 border-2 px-4 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         tabIndex={0}
         initial={false}
@@ -440,16 +440,16 @@ function MagneticPill({
         aria-label={tech.label}
       >
         {tech.icon ? (
-          <motion.div
+          <m.div
             initial={false}
             animate={{ color: getIconColor() }}
             transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
             aria-hidden="true"
           >
             <tech.icon className="h-4 w-4" />
-          </motion.div>
+          </m.div>
         ) : (
-          <motion.span
+          <m.span
             className="text-sm font-bold"
             initial={false}
             animate={{ color: isHovered ? "#ffffff" : tech.color }}
@@ -457,18 +457,18 @@ function MagneticPill({
             aria-hidden="true"
           >
             {tech.label.charAt(0)}
-          </motion.span>
+          </m.span>
         )}
-        <motion.span
+        <m.span
           className="text-sm font-semibold"
           initial={false}
           animate={{ color: getTextColor() }}
           transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
         >
           {tech.label}
-        </motion.span>
-      </motion.div>
-    </motion.div>
+        </m.span>
+      </m.div>
+    </m.div>
   );
 }
 
@@ -553,7 +553,7 @@ function CursorFollower({
   const y = useSpring(targetY, { stiffness: shape.stiffness, damping: shape.damping });
 
   return (
-    <motion.div
+    <m.div
       className="absolute top-0 left-0 border-2"
       style={{
         width: shape.size,

--- a/components/custom/home/Projects/projects.test.tsx
+++ b/components/custom/home/Projects/projects.test.tsx
@@ -2,51 +2,55 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-jest.mock("framer-motion", () => ({
-  motion: {
-    div: React.forwardRef<HTMLDivElement, any>(({ children, ...props }, ref) => (
-      <div ref={ref} {...props}>
-        {children}
-      </div>
-    )),
-    span: React.forwardRef<HTMLSpanElement, any>(({ children, ...props }, ref) => (
-      <span ref={ref} {...props}>
-        {children}
-      </span>
-    )),
-    article: React.forwardRef<HTMLElement, any>(({ children, ...props }, ref) => (
-      <article ref={ref as React.Ref<HTMLElement>} {...props}>
-        {children}
-      </article>
-    )),
-    p: React.forwardRef<HTMLParagraphElement, any>(({ children, ...props }, ref) => (
-      <p ref={ref} {...props}>
-        {children}
-      </p>
-    )),
-    ul: React.forwardRef<HTMLUListElement, any>(({ children, ...props }, ref) => (
-      <ul ref={ref} {...props}>
-        {children}
-      </ul>
-    )),
-    li: React.forwardRef<HTMLLIElement, any>(({ children, ...props }, ref) => (
-      <li ref={ref} {...props}>
-        {children}
-      </li>
-    )),
-    h3: React.forwardRef<HTMLHeadingElement, any>(({ children, ...props }, ref) => (
-      <h3 ref={ref} {...props}>
-        {children}
-      </h3>
-    )),
-  },
-  useMotionValue: () => ({ get: () => 0, set: jest.fn() }),
-  useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
-  useTransform: () => ({ get: () => 0 }),
-  useSpring: () => ({ get: () => 0 }),
-  useVelocity: () => ({ get: () => 0 }),
-  useReducedMotion: () => false,
-}));
+jest.mock("framer-motion", () => {
+  const _mock = {
+    motion: {
+      div: React.forwardRef<HTMLDivElement, any>(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      )),
+      span: React.forwardRef<HTMLSpanElement, any>(({ children, ...props }, ref) => (
+        <span ref={ref} {...props}>
+          {children}
+        </span>
+      )),
+      article: React.forwardRef<HTMLElement, any>(({ children, ...props }, ref) => (
+        <article ref={ref as React.Ref<HTMLElement>} {...props}>
+          {children}
+        </article>
+      )),
+      p: React.forwardRef<HTMLParagraphElement, any>(({ children, ...props }, ref) => (
+        <p ref={ref} {...props}>
+          {children}
+        </p>
+      )),
+      ul: React.forwardRef<HTMLUListElement, any>(({ children, ...props }, ref) => (
+        <ul ref={ref} {...props}>
+          {children}
+        </ul>
+      )),
+      li: React.forwardRef<HTMLLIElement, any>(({ children, ...props }, ref) => (
+        <li ref={ref} {...props}>
+          {children}
+        </li>
+      )),
+      h3: React.forwardRef<HTMLHeadingElement, any>(({ children, ...props }, ref) => (
+        <h3 ref={ref} {...props}>
+          {children}
+        </h3>
+      )),
+    },
+    useMotionValue: () => ({ get: () => 0, set: jest.fn() }),
+    useScroll: () => ({ scrollYProgress: { get: () => 0 } }),
+    useTransform: () => ({ get: () => 0 }),
+    useSpring: () => ({ get: () => 0 }),
+    useVelocity: () => ({ get: () => 0 }),
+    useReducedMotion: () => false,
+  };
+  _mock.m = _mock.motion;
+  return _mock;
+});
 
 jest.mock("@/components/custom/MagneticButton", () => ({
   MagneticButton: function MockMagneticButton({ children, ...props }: any) {

--- a/components/custom/home/Projects/projects.tsx
+++ b/components/custom/home/Projects/projects.tsx
@@ -3,7 +3,7 @@
 import { useRef, useCallback } from "react";
 import Image from "next/image";
 import {
-  motion,
+  m,
   useMotionValue,
   useReducedMotion,
   useScroll,
@@ -140,7 +140,7 @@ function MagneticBadge({ children, className }: { children: React.ReactNode; cla
   }, [x, y]);
 
   return (
-    <motion.span
+    <m.span
       ref={ref}
       className={className}
       style={{
@@ -155,7 +155,7 @@ function MagneticBadge({ children, className }: { children: React.ReactNode; cla
       onMouseLeave={handleMouseLeave}
     >
       {children}
-    </motion.span>
+    </m.span>
   );
 }
 
@@ -166,14 +166,14 @@ function SectionHeader() {
 
   return (
     <header className="mx-auto w-full max-w-7xl px-4 py-12 sm:px-6 sm:py-16 md:py-10">
-      <motion.div
+      <m.div
         className="mb-4 overflow-clip"
         initial={{ width: shouldReduceMotion ? "auto" : 0 }}
         whileInView={{ width: "auto" }}
         viewport={{ once: true }}
         transition={{ duration: 0.8, ease: EASE }}
       >
-        <motion.span
+        <m.span
           className="text-foreground inline-block px-3 py-1.5 text-xs font-bold tracking-[0.2em] sm:px-4 sm:py-2"
           style={{ backgroundColor: ACCENT, fontFamily: "var(--font-display)" }}
           initial={{ x: shouldReduceMotion ? 0 : -100 }}
@@ -182,8 +182,8 @@ function SectionHeader() {
           transition={{ duration: 0.6, delay: 0.3, ease: EASE }}
         >
           {t("badge")}
-        </motion.span>
-      </motion.div>
+        </m.span>
+      </m.div>
 
       <h2
         id="projects-heading"
@@ -192,7 +192,7 @@ function SectionHeader() {
       >
         {titleWords.map((word, i) => (
           <span key={i} className={`inline-block overflow-clip${i === 0 ? "mr-3 sm:mr-4" : ""}`}>
-            <motion.span
+            <m.span
               className="inline-block"
               style={{ color: i === 1 ? ACCENT : "inherit" }}
               initial={{ y: shouldReduceMotion ? 0 : "100%" }}
@@ -201,12 +201,12 @@ function SectionHeader() {
               transition={{ duration: 0.6, delay: 0.4 + i * 0.15, ease: EASE }}
             >
               {word}
-            </motion.span>
+            </m.span>
           </span>
         ))}
       </h2>
 
-      <motion.p
+      <m.p
         className="text-foreground/80 max-w-xl text-base sm:text-lg"
         initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 20 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -214,7 +214,7 @@ function SectionHeader() {
         transition={{ duration: 0.8, delay: 0.7, ease: EASE }}
       >
         {t("description")}
-      </motion.p>
+      </m.p>
     </header>
   );
 }
@@ -243,7 +243,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
           role="img"
           aria-label={`${project.title} project preview`}
         >
-          <motion.div
+          <m.div
             className="absolute inset-0 z-10"
             style={{ backgroundColor: ACCENT, originX: 0 }}
             initial={{ scaleX: 1 }}
@@ -256,7 +256,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
             }}
             aria-hidden="true"
           />
-          <motion.div
+          <m.div
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true, margin: "-20%" }}
@@ -285,13 +285,13 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
                 priority={project.id === 1}
               />
             </div>
-          </motion.div>
+          </m.div>
         </div>
 
         {/* Content */}
         <div className="w-full md:w-[60%] lg:w-[55%]">
           {/* Type badge */}
-          <motion.div
+          <m.div
             className="mb-3 sm:mb-4"
             initial={{ opacity: 0, x: 20 }}
             whileInView={{ opacity: 1, x: 0 }}
@@ -301,11 +301,11 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
             <MagneticBadge className="px-2.5 py-1 text-xs font-bold tracking-wide sm:px-3 sm:py-1.5">
               {t(`${project.i18nKey}.type`).toUpperCase()}
             </MagneticBadge>
-          </motion.div>
+          </m.div>
 
           {/* Title */}
-          <motion.div className="mb-3 overflow-clip sm:mb-4">
-            <motion.h3
+          <m.div className="mb-3 overflow-clip sm:mb-4">
+            <m.h3
               id={`project-title-${project.id}`}
               className="text-foreground text-2xl font-black sm:text-3xl md:text-4xl lg:text-5xl"
               style={{ fontFamily: "var(--font-display)" }}
@@ -315,11 +315,11 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
               transition={{ duration: 0.8, delay: 0.2, ease: EASE }}
             >
               {project.title}
-            </motion.h3>
-          </motion.div>
+            </m.h3>
+          </m.div>
 
           {/* Description */}
-          <motion.p
+          <m.p
             className="text-foreground/80 mb-4 text-sm leading-relaxed sm:mb-6 sm:text-base md:mb-3 md:text-sm lg:text-lg"
             initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 15 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -327,10 +327,10 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
             transition={{ duration: 0.8, delay: 0.3, ease: EASE }}
           >
             {t(`${project.i18nKey}.description`)}
-          </motion.p>
+          </m.p>
 
           {/* Tags */}
-          <motion.ul
+          <m.ul
             className="mb-6 flex flex-wrap items-center gap-x-2 gap-y-1.5 sm:mb-8 sm:gap-x-3 sm:gap-y-2 md:mb-4"
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
@@ -339,7 +339,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
             aria-label={`Technologies used in ${project.title}`}
           >
             {project.tags.map((tag, i) => (
-              <motion.li
+              <m.li
                 key={tag}
                 className="flex items-center gap-2 sm:gap-3"
                 initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 8 }}
@@ -351,12 +351,12 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
                 {i < project.tags.length - 1 && (
                   <span className="bg-foreground/30 h-1 w-1 rotate-45" aria-hidden="true" />
                 )}
-              </motion.li>
+              </m.li>
             ))}
-          </motion.ul>
+          </m.ul>
 
           {/* CTAs */}
-          <motion.div
+          <m.div
             className="flex flex-wrap gap-3 sm:gap-4"
             initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 15 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -385,7 +385,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
                 <ArrowUpRight className="ml-2 h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />
               </MagneticButton>
             )}
-          </motion.div>
+          </m.div>
         </div>
       </div>
     </>
@@ -394,7 +394,7 @@ function ProjectCardContent({ project }: { project: ProjectData }) {
 
 function MobileProjectCard({ project }: { project: ProjectData }) {
   return (
-    <motion.article
+    <m.article
       className="bg-background border-foreground/[0.08] relative border-b"
       aria-labelledby={`project-title-${project.id}`}
       initial={{ opacity: 0, y: 30 }}
@@ -403,7 +403,7 @@ function MobileProjectCard({ project }: { project: ProjectData }) {
       transition={{ duration: 0.6, ease: EASE }}
     >
       <ProjectCardContent project={project} />
-    </motion.article>
+    </m.article>
   );
 }
 
@@ -429,7 +429,7 @@ function DesktopProjectCard({
   );
 
   return (
-    <motion.article
+    <m.article
       className="bg-background absolute inset-0 flex items-center overflow-x-clip overflow-y-auto"
       style={{
         x: shouldReduceMotion ? 0 : xSlide,
@@ -438,7 +438,7 @@ function DesktopProjectCard({
       aria-labelledby={`project-title-${project.id}`}
     >
       <ProjectCardContent project={project} />
-    </motion.article>
+    </m.article>
   );
 }
 

--- a/components/custom/index.ts
+++ b/components/custom/index.ts
@@ -1,4 +1,5 @@
 export { LenisProvider, useLenis } from "./LenisProvider";
+export { MotionProvider } from "./MotionProvider";
 export { CustomCursor } from "./CustomCursor";
 export { AnimatedText, FadeIn, StaggerContainer, StaggerItem } from "./TextReveal";
 export { MagneticButton } from "./MagneticButton";

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -5,6 +5,7 @@ import { locales, defaultLocale } from "./config";
 export const routing = defineRouting({
   locales,
   defaultLocale,
+  localePrefix: "as-needed",
 });
 
 export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  experimental: {
+    inlineCss: true,
+  },
+};
 
 export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@formatjs/intl-localematcher": "^0.8.2",
     "clsx": "^2.1.1",
     "framer-motion": "^12.37.0",
-    "gsap": "^3.14.2",
     "lenis": "^1.3.18",
     "lucide-react": "^0.577.0",
     "negotiator": "^1.0.0",
@@ -26,9 +25,14 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.6.0",
-    "split-type": "^0.3.4",
     "tailwind-merge": "^3.5.0"
   },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       framer-motion:
         specifier: ^12.37.0
         version: 12.37.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      gsap:
-        specifier: ^3.14.2
-        version: 3.14.2
       lenis:
         specifier: ^1.3.18
         version: 1.3.18(react@19.2.3)
@@ -44,9 +41,6 @@ importers:
       react-icons:
         specifier: ^5.6.0
         version: 5.6.0(react@19.2.3)
-      split-type:
-        specifier: ^0.3.4
-        version: 0.3.4
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -2004,9 +1998,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gsap@3.14.2:
-    resolution: {integrity: sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==}
-
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -3128,9 +3119,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  split-type@0.3.4:
-    resolution: {integrity: sha512-otEk9vnD8qwfLsk3Lx0gz+qRkNIJCx0mlyL47ImP/DjMuV39d75Lpfwjn9fHteDRz0aoOblSzQjSNT9+Sswxcg==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -5560,8 +5548,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gsap@3.14.2: {}
-
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -6833,8 +6819,6 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
-
-  split-type@0.3.4: {}
 
   sprintf-js@1.0.3: {}
 

--- a/spec/07-performance-round2.md
+++ b/spec/07-performance-round2.md
@@ -1,0 +1,142 @@
+# Performance Optimization Round 2
+
+Target: Lighthouse mobile performance 95+, desktop 98+.
+
+## Current Baseline (2026-03-22, production)
+
+| Metric      | Mobile    | Desktop    |
+| ----------- | --------- | ---------- |
+| **Score**   | **89**    | **95**     |
+| FCP         | 2.1s (80) | 0.3s (100) |
+| LCP         | 3.3s (71) | 0.6s (99)  |
+| TBT         | 80ms (99) | 0ms (100)  |
+| CLS         | 0 (100)   | 0 (100)    |
+| Speed Index | 3.8s (83) | 2.3s (51)  |
+
+Previous rounds: 77 (spec 05) → 85 (spec 05) → 89 (spec 06) → 89 (current).
+
+## Failing Audits
+
+### 1. Locale redirect: `/` → `/en` (307) — ~810ms wasted on mobile
+
+The i18n middleware returns a 307 redirect from `/` to `/en`. Every first visit pays a full round-trip penalty before the document even starts loading.
+
+**Chunk:** `middleware.ts` using `next-intl/middleware`.
+
+### 2. Unused JavaScript — 42 KiB saveable
+
+| Chunk                                       | Transfer | Wasted   |
+| ------------------------------------------- | -------- | -------- |
+| `d2f170b530…` (Next.js runtime + polyfills) | 69.6 KiB | 21.9 KiB |
+| `910e5022a2…` (Next.js internals)           | 38.6 KiB | 20.0 KiB |
+
+### 3. Legacy JavaScript — 14 KiB of unnecessary polyfills
+
+All from `d2f170b530…`:
+
+- `Array.prototype.at`
+- `Array.prototype.flat` / `flatMap`
+- `Object.fromEntries`
+- `Object.hasOwn`
+- `String.prototype.trimEnd` / `trimStart`
+
+These are Baseline features supported by all modern browsers.
+
+### 4. Main-thread work — 2.9s on mobile
+
+| Category             | Time     |
+| -------------------- | -------- |
+| Script Evaluation    | 1,695 ms |
+| Other                | 488 ms   |
+| Style & Layout       | 314 ms   |
+| Garbage Collection   | 172 ms   |
+| Rendering            | 164 ms   |
+| Script Parse/Compile | 84 ms    |
+
+Top scripts by execution time:
+
+| Chunk                         | Total    | Scripting | Parse |
+| ----------------------------- | -------- | --------- | ----- |
+| `d2f170b530…` (runtime)       | 1,515 ms | 1,317 ms  | 24 ms |
+| `0497d1ed27…` (framer-motion) | 798 ms   | 336 ms    | 13 ms |
+
+### 5. Render-blocking CSS — 150ms
+
+`ec2cea036a65e487.css` (11.6 KiB) blocks first paint. This is the Tailwind output stylesheet.
+
+### 6. Network dependency chain — 1,328ms critical path
+
+```
+/en (20.67 KiB) — 1,216ms
+  └── ec2cea036a…css (11.63 KiB) — 1,328ms
+```
+
+---
+
+## Phase 1: Eliminate locale redirect
+
+The 307 from `/` → `/en` adds ~800ms on mobile. Convert to a rewrite so the browser gets content immediately without a round-trip.
+
+- [x] Change middleware from redirect to rewrite for the root path (`localePrefix: "as-needed"`)
+- [x] Ensure `/` serves `/en` content directly (200 with `x-middleware-rewrite: /en`)
+- [x] Verify deep links (`/es/...`) still work — `/en` redirects to `/` (correct `as-needed` behavior)
+- [x] Update canonical URLs and alternates in metadata
+
+---
+
+## Phase 2: Reduce JS bundle size
+
+### 2.1 Target modern browsers only (Legacy JS)
+
+- [x] Add `browserslist` config targeting last 2 versions of Chrome/Firefox/Safari/Edge
+- [ ] Verify the polyfills are no longer shipped (needs production deploy to confirm)
+
+### 2.2 LazyMotion migration
+
+- [x] Created `MotionProvider` wrapping app with `LazyMotion features={domMax} strict`
+- [x] Migrated all 29 component files from `motion` to `m` components
+- [x] Updated all 29 test files with `m` mock
+- [ ] Verify bundle size reduction (needs production deploy to confirm)
+
+### 2.3 Audit and reduce unused JS
+
+- [x] `gsap` — **removed** (unused dependency, never imported)
+- [x] `split-type` — **removed** (unused dependency, never imported)
+- [x] `lenis` — already dynamically imported in `LenisProvider`
+- [x] `react-icons/si` — justified (5 tech logos not available in lucide-react)
+- [x] `@formatjs/intl-localematcher` and `negotiator` — not imported in source, server-only via next-intl
+
+---
+
+## Phase 3: Reduce render-blocking CSS
+
+### 3.1 Inline critical CSS
+
+- [x] Enabled `experimental.inlineCss: true` in `next.config.ts` — CSS is inlined into HTML, eliminating render-blocking stylesheet request
+
+### 3.2 Font loading
+
+- [x] Verified: all 3 fonts use `display: "swap"` via `next/font`
+- [x] `next/font` handles preloading automatically
+- [x] JetBrains Mono only used below-fold (Experience, About) but deferring not worth the complexity
+
+---
+
+## Phase 4: Improve Speed Index
+
+- [x] Removed `hero-fade-in` keyframe — no more `opacity: 0` on any hero element
+- [x] Reduced animation delays: titles 0.1-0.2s (was 0.8-0.9s), tagline 0.3s (was 1.6s), CTA 0.4s (was 1.8s), pills 0.15s (was 0.5s)
+- [x] Shortened animation durations from 0.8s to 0.5-0.6s
+- [x] All hero content visible at opacity 1 from SSR — only transform animations during entrance
+
+---
+
+## Phase 5: Verification
+
+- [x] `pnpm build` passes
+- [x] `pnpm test` passes (388/388)
+- [x] `pnpm lint` passes
+- [ ] Run Lighthouse mobile audit — target: score 95+, LCP < 2.5s, FCP < 1.8s
+- [ ] Run Lighthouse desktop audit — target: score 98+
+- [ ] Visual verification: all animations still work
+- [ ] Test both locales (`/`, `/es`) and locale switching


### PR DESCRIPTION
## Summary

- Eliminate locale redirect (`/` → `/en` 307) by switching to `localePrefix: "as-needed"` — saves ~800ms on mobile
- Migrate all 29 components from `motion` to `m` (LazyMotion) for deferred feature loading
- Remove unused `gsap` and `split-type` dependencies
- Add `browserslist` config targeting modern browsers to eliminate legacy polyfills (14 KiB saved)
- Enable `experimental.inlineCss` to eliminate render-blocking CSS stylesheet
- Reduce hero animation delays 75-80% and remove `opacity: 0` fade-ins for faster visual completeness

## Local Lighthouse Results (production build)

| Metric | Before (prod) | After (local) |
|--------|---------------|---------------|
| Desktop Score | 95 | **100** |
| Speed Index (desktop) | 2.3s (51) | **0.5s (100)** |
| Speed Index (mobile) | 3.8s (83) | **2.2s (99)** |
| FCP (mobile) | 2.1s (80) | **1.0s (100)** |
| Redirects | 810ms wasted | **0ms** |
| Render-blocking CSS | 150ms | **eliminated** |
| Legacy JS polyfills | 14 KiB | **eliminated** |

## Test plan

- [x] Run PageSpeed Insights against deployed preview to validate production numbers
- [x] Visual verification: hero animations still work on both themes
- [x] Test locale switching (`/` → `/es` and back)
- [x] Verify `/en` redirects to `/` (correct `as-needed` behavior)
- [x] Verify `/es` serves directly (200)