### PR TITLE
fix: revert broken robots.txt middleware, restore inlineCss

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 
-const intlMiddleware = createMiddleware(routing);
-
-const ROBOTS_TXT = `User-Agent: *
-Allow: /
-
-Sitemap: https://drsm.vercel.app/sitemap.xml
-`;
-
-export default function middleware(request: NextRequest) {
-  if (request.nextUrl.pathname === "/robots.txt") {
-    return new NextResponse(ROBOTS_TXT, {
-      headers: { "Content-Type": "text/plain" },
-    });
-  }
-
-  return intlMiddleware(request);
-}
+export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/((?!_next|api|.*\\..*).*)", "/(robots\\.txt)"],
+  matcher: ["/((?!_next|api|.*\\..*).*)"],
 };


### PR DESCRIPTION
## Summary

- Revert the `robots.txt` middleware `NextResponse` body approach — it causes 500 errors on JS chunk serving
- Restore `inlineCss: true` (works on Vercel, only broken on `next start` locally)
- Middleware reverted to simple `next-intl` passthrough

## Why

PR #24 added a middleware that returned a `NextResponse` with a body for `/robots.txt`. This broke chunk serving with 500 errors, tanking Best Practices and Performance scores on production.

## Test plan

- [x] Verify no 500 console errors on production deploy
- [x] Verify Best Practices returns to 100
- [x] Verify performance scores recover to pre-#24 levels