### PR TITLE
v2.4.1

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 
-const intlMiddleware = createMiddleware(routing);
-
-const ROBOTS_TXT = `User-Agent: *
-Allow: /
-
-Sitemap: https://drsm.vercel.app/sitemap.xml
-`;
-
-export default function middleware(request: NextRequest) {
-  if (request.nextUrl.pathname === "/robots.txt") {
-    return new NextResponse(ROBOTS_TXT, {
-      headers: { "Content-Type": "text/plain" },
-    });
-  }
-
-  return intlMiddleware(request);
-}
+export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/((?!_next|api|.*\\..*).*)", "/(robots\\.txt)"],
+  matcher: ["/((?!_next|api|.*\\..*).*)"],
 };


### PR DESCRIPTION
## v2.4.1

Hotfix — revert broken robots.txt middleware that was causing 500 errors on chunk serving.

### Changes (#27)

**Revert broken middleware, restore inlineCss**

PR #24 introduced a middleware that returned a `NextResponse` body for `/robots.txt`. This caused 500 Internal Server Errors on all JS chunk requests, which tanked Best Practices (100 → 96) and degraded Performance scores.

- Reverted middleware to simple `next-intl` passthrough
- Restored `experimental.inlineCss: true` (works on Vercel, only broken on `next start` locally)

## Test plan

- [x] Verify no 500 console errors on production
- [x] Verify Best Practices returns to 100
- [x] Verify performance scores recover to pre-v2.4.0 levels
- [x] Run PageSpeed Insights after deploy